### PR TITLE
FIX: include user profile website URL with payload

### DIFF
--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -87,6 +87,7 @@ module DiscourseAkismet
         permalink: "#{Discourse.base_url}#{post.url}",
         comment_author: post.user.try(:username),
         comment_content: comment_content(post),
+        comment_author_url: post.user&.user_profile&.website,
         user_ip: post.custom_fields['AKISMET_IP_ADDRESS'],
         user_agent: post.custom_fields['AKISMET_USER_AGENT']
       }

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -14,7 +14,7 @@ module DiscourseAkismet
     def suspect?(user)
       SiteSetting.akismet_review_users? &&
         user.trust_level === TrustLevel[0] &&
-        user.user_profile.bio_raw.present? &&
+        (user.user_profile.bio_raw.present? || user.user_profile.website.present?) &&
         user.user_auth_token_logs&.last&.client_ip.present?
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -36,7 +36,7 @@ after_initialize do
   register_reviewable_type ReviewableAkismetUser
 
   add_model_callback(UserProfile, :before_save) do
-    if bio_raw_changed? && bio_raw.present?
+    if (bio_raw_changed? && bio_raw.present?) || (website_changed? && website.present?)
       DiscourseAkismet::UsersBouncer.new.enqueue_for_check(user)
     end
   end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe UserProfile do
       assert_checks_triggered(user_profile, 1)
     end
 
+    it 'triggers a job to check for spam when the user website changes' do
+      user_profile = user.user_profile
+      user_profile.website = "https://example.com/totally-legit-not-bogus-at-all/"
+
+      assert_checks_triggered(user_profile, 1)
+    end
+
     it "doesn't trigger a job when the the bio haven't changed" do
       assert_checks_triggered(user.user_profile, 0)
     end


### PR DESCRIPTION
When checking posts or user profiles, we should send the comment_author_url to held increase the accuraracy of results from Akismet.