### PR TITLE
FIX: The comment_content field is empty when the user has a website URL but not a bio.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     jaro_winkler (1.5.4)

--- a/lib/akismet.rb
+++ b/lib/akismet.rb
@@ -74,7 +74,7 @@ class Akismet
     def post(path, body)
       # Send a maximum of 32000 chars which is the default for
       # maximum post length site settings.
-      body[:comment_content] = body[:comment_content].strip[0..31999]
+      body[:comment_content] = body[:comment_content]&.strip[0..31999]
 
       response = Excon.post("#{@api_url}/#{path}",
         body: body.merge(blog: @base_url).to_query,


### PR DESCRIPTION
After 964a6e6, we send suspect users to Akismet if they have either a website or a bio set.