### PR TITLE
FEATURE: Send private message if post is not spam

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -27,3 +27,10 @@ en:
         A [staff member](%{base_url}/about) will review your post soon, and it should appear shortly.
 
         We apologize for the inconvenience.
+
+    akismet_not_spam:
+      subject_template: "Your post is no longer hidden"
+      text_body_template: |
+        Hello,
+
+        A [staff member](%{base_url}/about) reviewed [your post](%{post_link}) in *%{topic_title}* and it is now visible.

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -164,6 +164,14 @@ describe 'ReviewableAkismetPost' do
           DiscourseEvent.off(:post_recovered, &blk)
         end
       end
+
+      it 'Sends a system message to the user' do
+        expect { reviewable.perform admin, action }
+          .to change { Topic.private_messages.count }.by(1)
+
+        pm = Topic.private_messages.last
+        expect(pm.allowed_users).to contain_exactly(Discourse.system_user, post.user)
+      end
     end
 
     describe '#perform_ignore' do


### PR DESCRIPTION
The user receives a private message when the post is first marked as
spam and deleted. This commit enures that the user receives another
email after a staff member marked the post as 'not spam'.