### PR TITLE
FIX: Akismet reviewables shouldn't recalculate their score.

### DIFF
--- a/models/reviewable_akismet_post.rb
+++ b/models/reviewable_akismet_post.rb
@@ -73,7 +73,7 @@ class ReviewableAkismetPost < Reviewable
       UserDestroyer.new(performed_by).destroy(target_created_by, user_deletion_opts(performed_by))
     end
 
-    successful_transition :deleted, :agreed, recalculate_score: false
+    successful_transition :deleted, :agreed
   end
 
   private
@@ -82,9 +82,8 @@ class ReviewableAkismetPost < Reviewable
     DiscourseAkismet::PostsBouncer.new
   end
 
-  def successful_transition(to_state, update_flag_status, recalculate_score: true)
+  def successful_transition(to_state, update_flag_status)
     create_result(:success, to_state)  do |result|
-      result.recalculate_score = recalculate_score
       result.update_flag_stats = { status: update_flag_status, user_ids: [created_by_id] }
     end
   end

--- a/models/reviewable_akismet_user.rb
+++ b/models/reviewable_akismet_user.rb
@@ -38,7 +38,7 @@ class ReviewableAkismetUser < Reviewable
       UserDestroyer.new(performed_by).destroy(target, user_deletion_opts(performed_by))
     end
 
-    successful_transition :deleted, :agreed, recalculate_score: false
+    successful_transition :deleted, :agreed
   end
 
   private
@@ -47,9 +47,8 @@ class ReviewableAkismetUser < Reviewable
     DiscourseAkismet::UsersBouncer.new
   end
 
-  def successful_transition(to_state, update_flag_status, recalculate_score: true)
+  def successful_transition(to_state, update_flag_status)
     create_result(:success, to_state)  do |result|
-      result.recalculate_score = recalculate_score
       result.update_flag_stats = { status: update_flag_status, user_ids: [created_by_id] }
     end
   end


### PR DESCRIPTION
Related to discourse/discourse#13009. These reviewables are never re-flagged, so "recalculate_score" is not necessary.