### PR TITLE
FIX: Send not_spam message only if topic exists

### DIFF
--- a/models/reviewable_akismet_post.rb
+++ b/models/reviewable_akismet_post.rb
@@ -49,8 +49,7 @@ class ReviewableAkismetPost < Reviewable
 
     if post.deleted_at
       PostDestroyer.new(performed_by, post).recover
-      if SiteSetting.akismet_notify_user?
-        post.reload
+      if SiteSetting.akismet_notify_user? && post.reload.topic
         SystemMessage.new(post.user).create('akismet_not_spam', topic_title: post.topic.title, post_link: post.full_url)
       end
     end


### PR DESCRIPTION
It attempted to build a system message containing the topic title, but
that failed. This commit ensures that the message is skipped if the
topic is no longer accessible because it was deleted.