### PR TITLE
FIX: Don't trigger a spam check when a post is edited by a staff member.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -80,7 +80,10 @@ after_initialize do
 
   on(:post_edited) do |post, _, _|
     bouncer = DiscourseAkismet::PostsBouncer.new
-    check_post(bouncer, post) if bouncer.should_check?(post)
+
+    if post.last_editor.regular? && bouncer.should_check?(post)
+      check_post(bouncer, post)
+    end
   end
 
   on(:post_recovered) do |post, _, _|


### PR DESCRIPTION
Reported on meta: https://meta.discourse.org/t/edited-posts-flagged-as-spam/205959