### PR TITLE
FIX: Show akismet state only if it exists

### DIFF
--- a/assets/javascripts/discourse-akismet/connectors/flag-modal-bottom/akismet-status.hbs
+++ b/assets/javascripts/discourse-akismet/connectors/flag-modal-bottom/akismet-status.hbs
@@ -1,3 +1,5 @@
-<div class="consent_banner alert alert-info">
-  <span>{{i18n (concat "akismet.post_state." (or post.akismet_state "skipped"))}}.</span>
-</div>
+{{#if post.akismet_state}}
+  <div class="consent_banner alert alert-info">
+    <span>{{i18n (concat "akismet.post_state." post.akismet_state)}}.</span>
+  </div>
+{{/if}}


### PR DESCRIPTION
By default, it showed the "skipped" message which often produced more
confusion.