### PR TITLE
FIX: Deleting user works even if pending reviewables exist

### DIFF
--- a/lib/user_destroyer_extension.rb
+++ b/lib/user_destroyer_extension.rb
@@ -6,7 +6,9 @@ module DiscourseAkismet::UserDestroyerExtension
       ReviewableFlaggedPost.where(target_created_by: user).find_each do |reviewable|
         # The overriden `agree_with_flags` handles this reviewables, this
         # method just ensures that feedback is submitted.
-        DiscourseAkismet::PostsBouncer.new.submit_feedback(reviewable.target, 'spam')
+        if target = Post.with_deleted.find_by(id: reviewable.target_id)
+          DiscourseAkismet::PostsBouncer.new.submit_feedback(target, 'spam')
+        end
       end
 
       ReviewableAkismetPost.where(target_created_by: user).find_each do |reviewable|

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -125,5 +125,12 @@ describe 'plugin' do
       ReviewableAkismetPost.find_by(target: akismet_post).perform(Fabricate(:admin), :delete_user)
       expect(Jobs::UpdateAkismetStatus.jobs.count).to eq(2)
     end
+
+    it 'works even if pending posts were trashed' do
+      flagged_post.trash!
+      expect { ReviewableAkismetPost.find_by(target: akismet_post).perform(Fabricate(:admin), :delete_user) }
+        .not_to raise_error
+      expect(Jobs::UpdateAkismetStatus.jobs.count).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
Deleting and blocking users did not work if there were pending post
reviewables of trashed posts.