### PR TITLE
DEV: Make specs a bit less brittle

### DIFF
--- a/spec/jobs/regular/confirm_akismet_flagged_posts_spec.rb
+++ b/spec/jobs/regular/confirm_akismet_flagged_posts_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Jobs::ConfirmAkismetFlaggedPosts do
 
       updated_post_reviewable = @user_post_reviewable.reload
 
-      expect(updated_post_reviewable.status).to eq(Reviewable.statuses[:approved])
+      expect(updated_post_reviewable).to be_approved
     end
 
     it 'approves every flagged post even if the post was already deleted' do
@@ -38,7 +38,7 @@ RSpec.describe Jobs::ConfirmAkismetFlaggedPosts do
 
       updated_post_reviewable = @user_post_reviewable.reload
 
-      expect(updated_post_reviewable.status).to eq(Reviewable.statuses[:approved])
+      expect(updated_post_reviewable).to be_approved
     end
 
     it 'only approves pending flagged posts' do
@@ -47,7 +47,7 @@ RSpec.describe Jobs::ConfirmAkismetFlaggedPosts do
 
       updated_post_reviewable = @user_post_reviewable.reload
 
-      expect(updated_post_reviewable.status).to eq(Reviewable.statuses[:rejected])
+      expect(updated_post_reviewable).to be_rejected
     end
   end
 

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -122,7 +122,7 @@ describe DiscourseAkismet::PostsBouncer do
       subject.perform_check(client, post)
       reviewable_akismet_post = ReviewableAkismetPost.last
 
-      expect(reviewable_akismet_post.status).to eq Reviewable.statuses[:pending]
+      expect(reviewable_akismet_post).to be_pending
       expect(reviewable_akismet_post.post).to eq post
       expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
       expect(reviewable_akismet_post.payload['post_cooked']).to eq post.cooked
@@ -164,7 +164,7 @@ describe DiscourseAkismet::PostsBouncer do
       subject.perform_check(client, post)
       reviewable_akismet_post = ReviewableAkismetPost.last
 
-      expect(reviewable_akismet_post.status).to eq Reviewable.statuses[:pending]
+      expect(reviewable_akismet_post).to be_pending
       expect(reviewable_akismet_post.post).to eq post
       expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
       expect(reviewable_akismet_post.payload['external_error']['error']).to eq('status')

--- a/spec/lib/tasks/reviewables_spec.rb
+++ b/spec/lib/tasks/reviewables_spec.rb
@@ -64,11 +64,11 @@ describe 'Reviewables rake tasks' do
       run_migration
       reviewable = ReviewableAkismetPost.last
 
-      expect(reviewable.status).to eq reviewable_status_for(action)
+      expect(reviewable).to be_deleted
     end
 
     def assert_review_was_created_correctly(reviewable, state)
-      expect(reviewable.status).to eq reviewable_status_for(state)
+      expect(reviewable).to reviewable_status_for(state)
       expect(reviewable.target_id).to eq post.id
       expect(reviewable.topic_id).to eq post.topic_id
       expect(reviewable.reviewable_by_moderator).to eq true
@@ -112,7 +112,7 @@ describe 'Reviewables rake tasks' do
 
       def assert_score_was_create_correctly(score, reviewable, action)
         expect(score.user).to eq reviewable.created_by
-        expect(score.status).to eq score_status_for(action)
+        expect(score).to score_status_for(action)
         expect(score.reviewable_score_type).to eq spam_type
         expect(score.created_at).to eq_time reviewable.created_at
       end
@@ -120,13 +120,13 @@ describe 'Reviewables rake tasks' do
       def score_status_for(action)
         case action
         when 'needs_review'
-          ReviewableScore.statuses[:pending]
+          be_pending
         when 'dismissed'
-          ReviewableScore.statuses[:ignored]
+          be_ignored
         when 'confirmed_spam'
-          ReviewableScore.statuses[:agreed]
+          be_agreed
         else
-          ReviewableScore.statuses[:disagreed]
+          be_disagreed
         end
       end
 
@@ -134,18 +134,17 @@ describe 'Reviewables rake tasks' do
   end
 
   def reviewable_status_for(state)
-    reviewable_states = Reviewable.statuses
     case state
     when 'confirmed_spam'
-      reviewable_states[:approved]
+      be_approved
     when 'confirmed_ham'
-      reviewable_states[:rejected]
+      be_rejected
     when 'dismissed'
-      reviewable_states[:ignored]
+      be_ignored
     when 'confirmed_spam_deleted'
-      reviewable_states[:deleted]
+      be_deleted
     else
-      reviewable_states[:pending]
+      be_pending
     end
   end
 

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -13,7 +13,7 @@ describe 'ReviewableAkismetPost' do
     before { reviewable.created_new! }
 
     it 'Does not return available actions when the reviewable is no longer pending' do
-      available_actions = (Reviewable.statuses.keys - [:pending]).reduce([]) do |actions, status|
+      available_actions = (Reviewable.statuses.symbolize_keys.keys - [:pending]).reduce([]) do |actions, status|
         reviewable.status = Reviewable.statuses[status]
         an_action_id = :confirm_spam
 

--- a/spec/models/reviewable_akismet_user_spec.rb
+++ b/spec/models/reviewable_akismet_user_spec.rb
@@ -11,7 +11,7 @@ describe 'ReviewableAkismetUser' do
     let(:reviewable) { ReviewableAkismetUser.new }
 
     it 'does not return available actions when the reviewable is no longer pending' do
-      available_actions = (Reviewable.statuses.keys - [:pending]).reduce([]) do |actions, status|
+      available_actions = (Reviewable.statuses.symbolize_keys.keys - [:pending]).reduce([]) do |actions, status|
         reviewable.status = Reviewable.statuses[status]
         an_action_id = :not_spam
 
@@ -175,7 +175,7 @@ describe 'ReviewableAkismetUser' do
 
       reviewable.perform admin, :delete_user
 
-      expect(flagged_post_reviewable.reload.status).to eq(Reviewable.statuses[:approved])
+      expect(flagged_post_reviewable.reload).to be_approved
     end
   end
 end


### PR DESCRIPTION
As we’re going to use `ActiveRecord` enums instead of our current custom ones in core, we need to update some of the specs of this plugin otherwise they will break with the new changes.

(PR for core: https://github.com/discourse/discourse/pull/15330)