### PR TITLE
DEV: Use the new API for building reviewable score links to settings.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,8 +13,8 @@ en:
 
   reviewables:
     reasons:
-      akismet_spam_post: "Akismet flagged this post as potential spam. See more at `akismet` settings."
-      akismet_spam_user: "Akismet flagged this user as potential spam based on their trust level and user profile. See more at `akismet` settings."
+      akismet_spam_post: "Akismet flagged this post as potential spam. See more at %{link}."
+      akismet_spam_user: "Akismet flagged this user as potential spam based on their trust level and user profile. See more at %{link}."
 
   system_messages:
     akismet_spam:

--- a/plugin.rb
+++ b/plugin.rb
@@ -115,4 +115,7 @@ after_initialize do
 
   staff_actions = %i[confirmed_spam confirmed_ham ignored confirmed_spam_deleted]
   extend_list_method(UserHistory, :staff_actions, staff_actions)
+
+  add_reviewable_score_link(:akismet_spam_post, 'plugin:discourse-akismet')
+  add_reviewable_score_link(:akismet_spam_user, 'plugin:discourse-akismet')
 end


### PR DESCRIPTION
Discourse 2.8 added a new API for building links to site settings in the reviewable score reason. Before this API, we used backticks for this feature, but that proved problematic, as I explained [here](https://github.com/discourse/discourse/pull/14475).