### PR TITLE
Don't hardcode sending TL1's first post to akismet

### DIFF
--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -34,9 +34,6 @@ module DiscourseAkismet
       # We only check posts over 20 chars
       return false if stripped.size < 20
 
-      # Always check the first post of a TL1 user
-      return true if post.user.trust_level == TrustLevel[1] && post.user.post_count == 0
-
       # We only check certain trust levels
       return false if post.user.has_trust_level?(TrustLevel[SiteSetting.skip_akismet_trust_level.to_i])
 

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -34,6 +34,10 @@ module DiscourseAkismet
       # We only check posts over 20 chars
       return false if stripped.size < 20
 
+      # As a special case, check the first post of a TL1 user when checking TL0s is enabled
+      # this is because a user can gain TL1 in a single day without posting
+      return true if post.user.trust_level == TrustLevel[1] && post.user.post_count == 0 && SiteSetting.skip_akismet_trust_level.to_i > 0
+
       # We only check certain trust levels
       return false if post.user.has_trust_level?(TrustLevel[SiteSetting.skip_akismet_trust_level.to_i])
 


### PR DESCRIPTION
As highlighted by [this comment on discourse meta](https://meta.discourse.org/t/akismet-filter-misses-so-frequently-how-to-disable-improve/215935/2?u=mbauman), mandating a check on TL1's first post is quite counterintuitive.  ~~This simply removes that, leaning instead entirely on the trust level and post count site settings.~~ This patch now only turns this on if checking is enabled for TL0 users.