### PR TITLE
FIX: Make the review of a TL1 user's first post configurable.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -7,6 +7,7 @@ en:
     skip_akismet_posts: "Don't submit posts to Akismet if a user has posted this many times."
     akismet_notify_user: "Notify the user when Akismet has temporarily hidden a post."
     akismet_review_users: "Send TL0 user bios to Akismet for spam checking."
+    review_tl1_users_first_post: "Always review a TL1 user's first post."
 
   akismet:
     delete_reason: "determined by %{performed_by} to be a spammer"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,4 +16,6 @@ plugins:
     default: 50
   akismet_review_users:
     default: false
+  review_tl1_users_first_post:
+    default: true
 

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -35,7 +35,9 @@ module DiscourseAkismet
       return false if stripped.size < 20
 
       # Always check the first post of a TL1 user
-      return true if post.user.trust_level == TrustLevel[1] && post.user.post_count == 0
+      if SiteSetting.review_tl1_users_first_post? && post.user.trust_level == TrustLevel[1] && post.user.post_count == 0
+        return true
+      end
 
       # We only check certain trust levels
       return false if post.user.has_trust_level?(TrustLevel[SiteSetting.skip_akismet_trust_level.to_i])

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -214,7 +214,16 @@ describe DiscourseAkismet::PostsBouncer do
     end
 
     it 'returns true on the first post of a TL1 user' do
+      SiteSetting.skip_akismet_trust_level = TrustLevel[1]
+
       expect(subject.should_check?(post)).to eq(true)
+    end
+
+    it "returns false for a TL1 user's first post when the setting is disabled" do
+      SiteSetting.review_tl1_users_first_post = false
+      SiteSetting.skip_akismet_trust_level = TrustLevel[1]
+
+      expect(subject.should_check?(post)).to eq(false)
     end
 
     it 'returns false the topic was deleted' do


### PR DESCRIPTION
This check is important because TL1 is the only trust level that doesn't require visiting the forum multiple days. Combine this with the plugin's default settings, and a spammer could bypass Akismet by reading a couple of posts
before creating their own.

However, as pointed out in #51, the check is invisible to staff members and can't be disabled, even by setting `skip_akismet_trust_level` to 0.