### PR TITLE
Add support for NetEase text detection service

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,10 +8,10 @@ en:
     akismet_notify_user: "Notify the user when Akismet has temporarily hidden a post."
     akismet_review_users: "Send TL0 user bios to Akismet for spam checking."
     review_tl1_users_first_post: "Always review a TL1 user's first post."
-    anti_spam_service: "Anti-Spam service to use for automated content moderation"
-    netease_secret_id: "Netease API secret id"
-    netease_secret_key: "Netease API secret key"
-    netease_business_id: "Netease business id"
+    anti_spam_service: "Anti-Spam service to use for automated spam detection"
+    netease_secret_id: "NetEase API secret id"
+    netease_secret_key: "NetEase API secret key"
+    netease_business_id: "NetEase business id"
 
   akismet:
     delete_reason: "determined by %{performed_by} to be a spammer"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,6 @@
 en:
   site_settings:
-    akismet_enabled: 'Use Akismet to check for spam?'
+    akismet_enabled: 'Enable automated checking of spam?'
     akismet_api_key: 'Akismet API key for spam checking'
     akismet_transmit_email: "Send the poster's email to Akismet when confirming spam"
     skip_akismet_trust_level: "Don't submit posts to Akismet if the user is this trust level or higher."
@@ -8,6 +8,10 @@ en:
     akismet_notify_user: "Notify the user when Akismet has temporarily hidden a post."
     akismet_review_users: "Send TL0 user bios to Akismet for spam checking."
     review_tl1_users_first_post: "Always review a TL1 user's first post."
+    anti_spam_service: "Anti-Spam service to use for automated content moderation"
+    netease_secret_id: "Netease API secret id"
+    netease_secret_key: "Netease API secret key"
+    netease_business_id: "Netease business id"
 
   akismet:
     delete_reason: "determined by %{performed_by} to be a spammer"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,9 +2,22 @@ plugins:
   akismet_enabled:
     default: false
     shadowed_by_global: true
+  anti_spam_service:
+    default: "akismet"
+    type: enum
+    choices:
+      - akismet
+      - netease
   akismet_api_key:
-    default: ''
+    default: ""
     shadowed_by_global: true
+  netease_secret_id:
+    default: ""
+  netease_secret_key:
+    default: ""
+    secret: true
+  netease_business_id:
+    default: ""
   akismet_transmit_email:
     default: true
   skip_akismet_trust_level:

--- a/jobs/regular/check_akismet_post.rb
+++ b/jobs/regular/check_akismet_post.rb
@@ -9,7 +9,10 @@ module Jobs
 
       DistributedMutex.synchronize("akismet_post_#{post.id}") do
         if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
-          DiscourseAkismet::PostsBouncer.new.perform_check(Akismet::Client.build_client, post)
+          DiscourseAkismet::PostsBouncer.new.perform_check(
+            DiscourseAkismet::AntiSpamService.client,
+            post,
+          )
         end
       end
     end

--- a/jobs/regular/check_akismet_user.rb
+++ b/jobs/regular/check_akismet_user.rb
@@ -9,7 +9,10 @@ module Jobs
 
       DistributedMutex.synchronize("akismet_user_#{user.id}") do
         if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
-          DiscourseAkismet::UsersBouncer.new.perform_check(Akismet::Client.build_client, user)
+          DiscourseAkismet::UsersBouncer.new.perform_check(
+            DiscourseAkismet::AntiSpamService.client,
+            user,
+          )
         end
       end
     end

--- a/jobs/regular/update_akismet_status.rb
+++ b/jobs/regular/update_akismet_status.rb
@@ -10,7 +10,7 @@ module Jobs
       raise Discourse::InvalidParameters.new(:feedback) unless akismet_feedback
       raise Discourse::InvalidParameters.new(:status) unless status
 
-      client = Akismet::Client.build_client
+      client = DiscourseAkismet::AntiSpamService.client
       client.submit_feedback(status, akismet_feedback)
     end
   end

--- a/jobs/scheduled/check_for_spam_posts.rb
+++ b/jobs/scheduled/check_for_spam_posts.rb
@@ -9,7 +9,7 @@ module Jobs
       return if SiteSetting.akismet_api_key.blank?
 
       bouncer = DiscourseAkismet::PostsBouncer.new
-      client = Akismet::Client.build_client
+      client = DiscourseAkismet::AntiSpamService.client
       spam_count = 0
 
       DiscourseAkismet::PostsBouncer

--- a/jobs/scheduled/check_for_spam_posts.rb
+++ b/jobs/scheduled/check_for_spam_posts.rb
@@ -6,7 +6,7 @@ module Jobs
 
     def execute(args)
       return unless SiteSetting.akismet_enabled?
-      return if SiteSetting.akismet_api_key.blank?
+      return if DiscourseAkismet::AntiSpamService.api_secret_blank?
 
       bouncer = DiscourseAkismet::PostsBouncer.new
       client = DiscourseAkismet::AntiSpamService.client

--- a/jobs/scheduled/check_for_spam_users.rb
+++ b/jobs/scheduled/check_for_spam_users.rb
@@ -9,7 +9,7 @@ module Jobs
       return if SiteSetting.akismet_api_key.blank?
 
       bouncer = DiscourseAkismet::UsersBouncer.new
-      client = Akismet::Client.build_client
+      client = DiscourseAkismet::AntiSpamService.client
 
       DiscourseAkismet::UsersBouncer
         .to_check

--- a/jobs/scheduled/check_for_spam_users.rb
+++ b/jobs/scheduled/check_for_spam_users.rb
@@ -6,7 +6,7 @@ module Jobs
 
     def execute(args)
       return unless SiteSetting.akismet_enabled?
-      return if SiteSetting.akismet_api_key.blank?
+      return if DiscourseAkismet::AntiSpamService.api_secret_blank?
 
       bouncer = DiscourseAkismet::UsersBouncer.new
       client = DiscourseAkismet::AntiSpamService.client

--- a/lib/akismet.rb
+++ b/lib/akismet.rb
@@ -6,6 +6,86 @@ class Akismet
   class Error < StandardError
   end
 
+  class RequestParams
+    def initialize(target, munger = nil)
+      @target = target
+      @munger = munger
+    end
+
+    def for_check
+      send("for_#{target_name}_check")
+    end
+
+    def for_feedback
+      send("for_#{target_name}_feedback")
+    end
+
+    private
+
+    def for_user_check
+      profile = @target.user_profile
+      token = @target.user_auth_token_logs.last
+
+      extra_args = {
+        blog: Discourse.base_url,
+        content_type: "signup",
+        permalink: "#{Discourse.base_url}/u/#{@target.username_lower}",
+        comment_author: @target.username,
+        comment_content: profile&.bio_raw,
+        comment_author_url: profile&.website,
+        user_ip: token&.client_ip&.to_s,
+        user_agent: token&.user_agent,
+      }
+
+      # Sending the email to akismet is optional
+      extra_args[:comment_author_email] = @target.email if SiteSetting.akismet_transmit_email?
+
+      @munger.call(extra_args) if @munger
+
+      extra_args
+    end
+
+    def for_post_check
+      extra_args = {
+        blog: Discourse.base_url,
+        content_type: @target.is_first_post? ? "forum-post" : "reply",
+        referrer: @target.custom_fields["AKISMET_REFERRER"],
+        permalink: "#{Discourse.base_url}#{@target.url}",
+        comment_author: @target.user.try(:username),
+        comment_content: post_content,
+        comment_author_url: @target.user&.user_profile&.website,
+        user_ip: @target.custom_fields["AKISMET_IP_ADDRESS"],
+        user_agent: @target.custom_fields["AKISMET_USER_AGENT"],
+      }
+
+      # Sending the email to akismet is optional
+      if SiteSetting.akismet_transmit_email?
+        extra_args[:comment_author_email] = @target.user.try(:email)
+      end
+
+      @munger.call(extra_args) if @munger
+      extra_args
+    end
+
+    def for_user_feedback
+    end
+
+    def for_post_feedback
+    end
+
+    def target_name
+      @target.class.to_s.downcase
+    end
+
+    def post_content
+      return unless @target.is_a?(Post)
+      return @target.raw unless @target.is_first_post?
+
+      topic = @target.topic || Topic.with_deleted.find_by(id: @target.topic_id)
+      "#{topic && topic.title}\n\n#{@target.raw}"
+    end
+  end
+
   class Client
     PLUGIN_NAME = "discourse-akismet".freeze
     VALID_COMMENT_CHECK_RESPONSE = %w[true false].each(&:freeze)

--- a/lib/discourse_akismet/anti_spam_service.rb
+++ b/lib/discourse_akismet/anti_spam_service.rb
@@ -5,18 +5,28 @@ module DiscourseAkismet
     def self.client
       return if !SiteSetting.akismet_enabled?
 
-      api =
-        if SiteSetting.anti_spam_service == "netease"
-          Netease::Client
-        else
-          Akismet::Client
-        end
-
-      api.build_client
+      netease? ? Netease::Client.build_client : Akismet::Client.build_client
     end
 
-    def self.request_params_manager
-      SiteSetting.anti_spam_service == "netease" ? Netease::RequestParams : Akismet::RequestParams
+    def self.args_manager
+      netease? ? Netease::RequestArgs : Akismet::RequestArgs
+    end
+
+    def self.api_secret_configured?
+      if netease?
+        SiteSetting.netease_secret_id.present? && SiteSetting.netease_secret_key.present? &&
+          SiteSetting.netease_business_id.present?
+      else
+        SiteSetting.akismet_api_key.present?
+      end
+    end
+
+    def self.api_secret_blank?
+      !api_secret_configured?
+    end
+
+    def self.netease?
+      SiteSetting.anti_spam_service == "netease"
     end
   end
 end

--- a/lib/discourse_akismet/anti_spam_service.rb
+++ b/lib/discourse_akismet/anti_spam_service.rb
@@ -14,5 +14,9 @@ module DiscourseAkismet
 
       api.build_client
     end
+
+    def self.request_params_manager
+      SiteSetting.anti_spam_service == "netease" ? Netease::RequestParams : Akismet::RequestParams
+    end
   end
 end

--- a/lib/discourse_akismet/anti_spam_service.rb
+++ b/lib/discourse_akismet/anti_spam_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DiscourseAkismet
+  class AntiSpamService
+    def self.client
+      return if !SiteSetting.akismet_enabled?
+
+      api =
+        if SiteSetting.anti_spam_service == "netease"
+          Netease::Client
+        else
+          Akismet::Client
+        end
+
+      api.build_client
+    end
+  end
+end

--- a/lib/discourse_akismet/bouncer.rb
+++ b/lib/discourse_akismet/bouncer.rb
@@ -8,7 +8,7 @@ module DiscourseAkismet
 
     def submit_feedback(target, status)
       raise Discourse::InvalidParameters.new(:status) unless VALID_STATUSES.include?(status)
-      feedback = args_for(target).for_feedback
+      feedback = args_for(target, "feedback")
 
       Jobs.enqueue(:update_akismet_status, feedback: feedback, status: status)
     end
@@ -18,7 +18,7 @@ module DiscourseAkismet
     end
 
     def move_to_state(target, state)
-      return if target.blank? || SiteSetting.akismet_api_key.blank? || !VALID_STATES.include?(state)
+      return if target.blank? || AntiSpamService.api_secret_blank? || !VALID_STATES.include?(state)
       target.upsert_custom_fields(AKISMET_STATE => state)
     end
 
@@ -26,10 +26,11 @@ module DiscourseAkismet
       pre_check_passed = before_check(target)
 
       if pre_check_passed
-        args = args_for(target).for_check
+        args = args_for(target, "check")
         client
           .comment_check(args)
           .tap do |result, error_status|
+            target.reload
             case result
             when "spam"
               mark_as_spam(target)

--- a/lib/discourse_akismet/bouncer.rb
+++ b/lib/discourse_akismet/bouncer.rb
@@ -8,7 +8,7 @@ module DiscourseAkismet
 
     def submit_feedback(target, status)
       raise Discourse::InvalidParameters.new(:status) unless VALID_STATUSES.include?(status)
-      feedback = args_for(target)
+      feedback = args_for(target).for_feedback
 
       Jobs.enqueue(:update_akismet_status, feedback: feedback, status: status)
     end
@@ -26,7 +26,7 @@ module DiscourseAkismet
       pre_check_passed = before_check(target)
 
       if pre_check_passed
-        args = args_for(target)
+        args = args_for(target).for_check
         client
           .comment_check(args)
           .tap do |result, error_status|

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -83,25 +83,8 @@ module DiscourseAkismet
     end
 
     def args_for(post)
-      extra_args = {
-        blog: Discourse.base_url,
-        content_type: post.is_first_post? ? "forum-post" : "reply",
-        referrer: post.custom_fields["AKISMET_REFERRER"],
-        permalink: "#{Discourse.base_url}#{post.url}",
-        comment_author: post.user.try(:username),
-        comment_content: comment_content(post),
-        comment_author_url: post.user&.user_profile&.website,
-        user_ip: post.custom_fields["AKISMET_IP_ADDRESS"],
-        user_agent: post.custom_fields["AKISMET_USER_AGENT"],
-      }
-
-      # Sending the email to akismet is optional
-      if SiteSetting.akismet_transmit_email?
-        extra_args[:comment_author_email] = post.user.try(:email)
-      end
-
-      @@munger.call(extra_args) if @@munger
-      extra_args
+      params_manager = AntiSpamService.request_params_manager
+      params_manager.new(post, @@munger)
     end
 
     private

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -20,24 +20,8 @@ module DiscourseAkismet
     end
 
     def args_for(user)
-      profile = user.user_profile
-      token = user.user_auth_token_logs.last
-
-      extra_args = {
-        blog: Discourse.base_url,
-        content_type: "signup",
-        permalink: "#{Discourse.base_url}/u/#{user.username_lower}",
-        comment_author: user.username,
-        comment_content: profile&.bio_raw,
-        comment_author_url: profile&.website,
-        user_ip: token&.client_ip&.to_s,
-        user_agent: token&.user_agent,
-      }
-
-      # Sending the email to akismet is optional
-      extra_args[:comment_author_email] = user.email if SiteSetting.akismet_transmit_email?
-
-      extra_args
+      params_manager = AntiSpamService.request_params_manager
+      params_manager.new(user)
     end
 
     private

--- a/lib/discourse_akismet/users_bouncer.rb
+++ b/lib/discourse_akismet/users_bouncer.rb
@@ -19,9 +19,10 @@ module DiscourseAkismet
         user.user_auth_token_logs&.last&.client_ip.present?
     end
 
-    def args_for(user)
-      params_manager = AntiSpamService.request_params_manager
-      params_manager.new(user)
+    def args_for(user, action)
+      args = AntiSpamService.args_manager.new(user)
+
+      action == "check" ? args.for_check : args.for_feedback
     end
 
     private

--- a/lib/netease.rb
+++ b/lib/netease.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "excon"
+
+class Netease
+  class Error < StandardError
+  end
+
+  class Client
+    PLUGIN_NAME = "discourse-akismet".freeze
+    MAXIMUM_TEXT_LENGTH = 9999
+    NETEASE_CHECK_VERSION = "v5.2".freeze
+    NETEASE_FEEDBACK_VERSION = "v2".freeze
+
+    def initialize(api_secret:, business_id:, base_url:)
+      @api_secret = api_secret
+      @business_id = business_id
+      @api_base_url = "http://as.dun.163.com"
+      @base_url = base_url
+    end
+
+    def self.build_client
+      api_secret = { id: SiteSetting.netease_secret_id, key: SiteSetting.netease_secret_key }
+
+      new(
+        api_secret: api_secret,
+        business_id: SiteSetting.netease_business_id,
+        base_url: Discourse.base_url,
+      )
+    end
+
+    def comment_check(body)
+      response = post("v5/text/check", payload_with_signature(body))
+      response_body = JSON.parse(response.body)
+
+      if response_body["code"] != 200
+        api_error = {
+          code: response_body["code"],
+          msg: response_body["msg"],
+          error: response_body["error"],
+        }
+
+        return "error", api_error.compact
+      end
+
+      response_body.dig("result", "antispam", "suggestion") != 0 ? "spam" : "ham"
+    end
+
+    def submit_feedback(state, body)
+      # feedback_list = [{
+      #   taskId: body[:netease_task_id],
+      #   level: state == "spam" ? 0 : 2
+      # }]
+
+      # response = post("v2/text/feedback", body)
+      # response_body = response.body
+
+      true
+    end
+
+    private
+
+    def self.user_agent_string
+      @user_agent_string ||=
+        begin
+          plugin_version =
+            Discourse.plugins.find { |plugin| plugin.name == PLUGIN_NAME }.metadata.version
+
+          "Discourse/#{Discourse::VERSION::STRING} | #{PLUGIN_NAME}/#{plugin_version}"
+        end
+    end
+
+    def post(path, body)
+      response =
+        Excon.post(
+          "#{@api_base_url}/#{path}",
+          body: body.to_query,
+          headers: {
+            "Content-Type" => "application/x-www-form-urlencoded",
+            "User-Agent" => self.class.user_agent_string,
+          },
+        )
+
+      raise Netease::Error.new(response.status_line) if response.status != 200
+
+      response
+    end
+
+    def payload_with_signature(body)
+      body[:comment_content] = body[:comment_content].strip[0..MAXIMUM_TEXT_LENGTH] if body[
+        :comment_content
+      ]
+
+      payload = {
+        secretId: @api_secret[:id],
+        businessId: @business_id,
+        timestamp: Time.now.strftime("%s%L").to_i,
+        nonce: SecureRandom.random_number(1_000_000_000_000_0),
+        signatureMethod: "MD5",
+        dataId: body[:permalink].strip[0..127],
+        content: body[:comment_content],
+        version: NETEASE_CHECK_VERSION,
+      }
+
+      signature_str = ""
+      payload.sort.to_h.keys.each { |k| signature_str += k.to_s + payload[k].to_s }
+
+      signature_str << @api_secret[:key]
+      signature_str.force_encoding("UTF-8")
+
+      payload[:signature] = Digest::MD5.hexdigest(signature_str)
+
+      payload
+    end
+  end
+end

--- a/lib/netease.rb
+++ b/lib/netease.rb
@@ -8,7 +8,7 @@ class Netease
   class Error < StandardError
   end
 
-  class RequestParams
+  class RequestArgs
     def initialize(target, munger = nil)
       @target = target
       @munger = munger
@@ -19,25 +19,30 @@ class Netease
     end
 
     def for_feedback
-      send("for_#{target_name}_feedback")
+      { feedback: { taskId: @target.custom_fields["NETEASE_TASK_ID"] } }
     end
 
     private
 
     def for_post_check
-      { dataId: "post-#{@target.id}", content: post_content.strip[0..MAXIMUM_CONTENT_LENGTH] }
+      args = {
+        dataId: "post-#{@target.id}",
+        content: post_content&.strip[0..MAXIMUM_CONTENT_LENGTH],
+      }
+
+      @munger.call(args) if @munger
+
+      args
     end
 
     def for_user_check
       bio = @target.user_profile&.bio_raw
 
-      { dataId: "user-#{@target.id}", content: bio&.strip[0..MAXIMUM_CONTENT_LENGTH] }
-    end
+      args = { dataId: "user-#{@target.id}", content: bio&.strip[0..MAXIMUM_CONTENT_LENGTH] }
 
-    def for_post_feedback
-    end
+      @munger.call(args) if @munger
 
-    def for_user_feedback
+      args
     end
 
     def target_name
@@ -45,7 +50,8 @@ class Netease
     end
 
     def post_content
-      return @target.raw unless @target.is_first_post?
+      return if !@target.is_a?(Post)
+      return @target.raw if !@target.is_first_post?
 
       topic = @target.topic || Topic.with_deleted.find_by(id: @target.topic_id)
       "#{topic && topic.title}\n\n#{@target.raw}"
@@ -54,12 +60,13 @@ class Netease
 
   class Client
     PLUGIN_NAME = "discourse-akismet"
-    MAXIMUM_TEXT_LENGTH = 9999
     CHECK_VERSION = "v5.2"
     FEEDBACK_VERSION = "v2"
     FEEDBACK_PATH = "v2/text/feedback"
     CHECK_PATH = "v5/text/check"
-    BASE_URL = "http://as.dun.163.com"
+    API_BASE_URL = "http://as.dun.163.com"
+    HASH_ALGORITHM = "MD5"
+    NONCE_UPPER_BOUND = 100_000 * 100_000 * 10
 
     def initialize(api_secret:, business_id:, base_url:)
       @api_secret = api_secret
@@ -78,48 +85,97 @@ class Netease
     end
 
     def comment_check(body)
-      response = post(CHECK_PATH, payload_with_signature(body))
-      response_body = JSON.parse(response.body)
+      payload = body.merge(comment_check_base_payload)
+      payload[:signature] = signature(payload)
+
+      response = post(CHECK_PATH, payload)
+      response_body =
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError
+          {}
+        end
 
       if response_body["code"] != 200
         api_error = {
-          code: response_body["code"],
+          code: response_body["code"].to_s,
           msg: response_body["msg"],
-          error: response_body["error"],
+          error: response_body["msg"],
         }
 
         return "error", api_error.compact
       end
 
-      response_body.dig("result", "antispam", "suggestion") != 0 ? "spam" : "ham"
+      anti_spam_result = response_body.dig("result", "antispam") || {}
+      task_id = anti_spam_result["taskId"]
+
+      # TODO(selase) This should handled in caller. Quick hack to ensure interface compatibility for now
+      target_name, id = body[:dataId].split("-")
+      log_task_id(target_name, id.to_i, task_id)
+
+      anti_spam_result["suggestion"] != 0 ? "spam" : "ham"
     end
 
     def submit_feedback(state, body)
-      return false if body[:comment_content].blank?
+      feedback = body[:feedback]
 
-      feedback_list = [{ taskId: body[:netease_task_id], level: state == "ham" ? 0 : 2 }]
+      return false if feedback[:taskId].blank?
 
-      payload = {
-        secretId: @api_secret[:id],
-        businessId: @business_id,
-        timestamp: Time.now.strftime("%s%L").to_i,
-        nonce: SecureRandom.random_number(1_000_000_000_000_0),
-        signatureMethod: "MD5",
-        version: FEEDBACK_VERSION,
-        feedbacks: JSON.dump(feedback_list),
-      }
-
+      payload = {}
+      feedback.merge!(level: state == "ham" ? 0 : 2)
+      payload = feedback_base_payload
+      payload[:feedbacks] = JSON.dump([feedback])
       payload[:signature] = signature(payload)
 
       response = post(FEEDBACK_PATH, payload)
-      response_body = JSON.parse(response.body)
+      response_body =
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError
+          {}
+        end
 
       raise Netease::Error.new(response_body["msg"]) if response_body["code"] != 200
 
       true
     end
 
+    def base_payload
+      {
+        secretId: @api_secret[:id],
+        businessId: @business_id,
+        timestamp: Time.now.strftime("%s%L").to_i,
+        nonce: nonce,
+        signatureMethod: HASH_ALGORITHM,
+      }
+    end
+
+    def nonce
+      SecureRandom.random_number(NONCE_UPPER_BOUND)
+    end
+
+    def comment_check_base_payload
+      base_payload.merge(version: CHECK_VERSION)
+    end
+
+    def feedback_base_payload
+      base_payload.merge(version: FEEDBACK_VERSION)
+    end
+
     private
+
+    def log_task_id(target_name, id, task_id)
+      return if %w[user post].exclude?(target_name)
+
+      target =
+        if target_name == "user"
+          User.find_by(id: id)
+        else
+          Post.with_deleted.find_by(id: id)
+        end
+
+      target.upsert_custom_fields("NETEASE_TASK_ID" => task_id) if target
+    end
 
     def signature(payload)
       signature_str = ""
@@ -144,7 +200,7 @@ class Netease
     def post(path, body)
       response =
         Excon.post(
-          "#{BASE_URL}/#{path}",
+          "#{API_BASE_URL}/#{path}",
           body: body.to_query,
           headers: {
             "Content-Type" => "application/x-www-form-urlencoded",
@@ -152,30 +208,9 @@ class Netease
           },
         )
 
-      raise Netease::Error.new(response.status_line) if response.status != 200
+      raise Netease::Error.new(response.status_line) if [200, 201].exclude?(response.status)
 
       response
-    end
-
-    def payload_with_signature(body)
-      body[:comment_content] = body[:comment_content].strip[0..MAXIMUM_TEXT_LENGTH] if body[
-        :comment_content
-      ]
-
-      payload = {
-        secretId: @api_secret[:id],
-        businessId: @business_id,
-        timestamp: Time.now.strftime("%s%L").to_i,
-        nonce: SecureRandom.random_number(1_000_000_000_000_0),
-        signatureMethod: "MD5",
-        dataId: body[:permalink].strip[0..127],
-        content: body[:comment_content],
-        version: CHECK_VERSION,
-      }
-
-      payload[:signature] = signature(payload)
-
-      payload
     end
   end
 end

--- a/lib/tasks/akismet.rake
+++ b/lib/tasks/akismet.rake
@@ -41,7 +41,7 @@ task "akismet:scan_old" => :environment do
   DiscourseAkismet::PostsBouncer.munge_args { |args| args[:recheck_reason] = "recheck_queue" }
 
   bouncer = DiscourseAkismet::PostsBouncer.new
-  client = Akismet::Client.build_client
+  client = DiscourseAkismet::AntiSpamService.client
 
   spam_count = 0
   not_spam_count = 0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,1 @@
-{
-  "author": "Discourse",
-  "license": "MIT",
-  "devDependencies": {
-    "eslint-config-discourse": "^3.3.0"
-  }
-}
+{ author: "Discourse", license: "MIT", devDependencies: { "eslint-config-discourse": "^3.3.0" } }

--- a/package.json
+++ b/package.json
@@ -1,1 +1,7 @@
-{ author: "Discourse", license: "MIT", devDependencies: { "eslint-config-discourse": "^3.3.0" } }
+{
+  "author": "Discourse",
+  "license": "MIT",
+  "devDependencies": {
+    "eslint-config-discourse": "^3.3.0"
+  }
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -9,11 +9,13 @@
 
 enabled_site_setting :akismet_enabled
 
+require_relative "lib/discourse_akismet/anti_spam_service.rb"
 require_relative "lib/discourse_akismet/bouncer.rb"
 require_relative "lib/discourse_akismet/engine.rb"
 require_relative "lib/discourse_akismet/posts_bouncer.rb"
 require_relative "lib/discourse_akismet/users_bouncer.rb"
 require_relative "lib/akismet.rb"
+require_relative "lib/netease.rb"
 
 register_asset "stylesheets/akismet.scss"
 

--- a/spec/jobs/regular/check_akismet_post_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_spec.rb
@@ -24,12 +24,68 @@ RSpec.describe Jobs::CheckAkismetPost do
       expect(ReviewableAkismetPost.count).to be_zero
     end
 
-    it "does not create a reviewable when the post is not spam" do
-      Akismet::Client.any_instance.stubs(:comment_check).returns(false)
+    shared_examples "confirmed ham posts" do
+      it "does not create a reviewable for non-spam post" do
+        subject.execute(post_id: post.id)
 
-      subject.execute(post_id: post.id)
+        expect(ReviewableAkismetPost.count).to be_zero
+        expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
+          "confirmed_ham",
+        )
+      end
+    end
 
-      expect(ReviewableAkismetPost.count).to be_zero
+    shared_examples "confirmed spam posts" do
+      it "creates a reviewable for spam post" do
+        subject.execute(post_id: post.id)
+
+        expect(ReviewableAkismetPost.count).to eq(1)
+        expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
+          "confirmed_spam",
+        )
+      end
+    end
+
+    context "with akismet" do
+      before do
+        SiteSetting.anti_spam_service = "akismet"
+        SiteSetting.akismet_api_key = "fake_key"
+        DiscourseAkismet::PostsBouncer.new.move_to_state(post, "pending")
+      end
+
+      context "when client returns spam" do
+        before { Akismet::Client.any_instance.stubs(:comment_check).returns("spam") }
+
+        include_examples "confirmed spam posts"
+      end
+
+      context "when client returns ham" do
+        before { Akismet::Client.any_instance.stubs(:comment_check).returns("ham") }
+
+        include_examples "confirmed ham posts"
+      end
+    end
+
+    context "with netease" do
+      before do
+        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
+        DiscourseAkismet::PostsBouncer.new.move_to_state(post, "pending")
+      end
+
+      context "when client returns spam" do
+        before { Netease::Client.any_instance.stubs(:comment_check).returns("spam") }
+
+        include_examples "confirmed spam posts"
+      end
+
+      context "when client returns ham" do
+        before { Netease::Client.any_instance.stubs(:comment_check).returns("ham") }
+
+        include_examples "confirmed ham posts"
+      end
     end
   end
 end

--- a/spec/jobs/scheduled/check_for_spam_users_spec.rb
+++ b/spec/jobs/scheduled/check_for_spam_users_spec.rb
@@ -4,27 +4,79 @@ require "rails_helper"
 
 RSpec.describe Jobs::CheckForSpamUsers do
   before do
-    SiteSetting.akismet_review_users = true
-    SiteSetting.akismet_api_key = "fake_key"
     SiteSetting.akismet_enabled = true
+    SiteSetting.akismet_review_users = true
   end
 
-  it "works" do
-    fake_client =
-      mock("Akismet::Client").tap { |client| client.expects(:comment_check).returns(false) }
-    Akismet::Client.expects(:new).returns(fake_client)
+  shared_examples "check users" do
+    it "updates pending user's akismet state" do
+      fake_client =
+        mock(client_name).tap do |client|
+          client.expects(:comment_check).returns(comment_check_result)
+        end
+      client_name.constantize.expects(:new).returns(fake_client)
 
-    user =
-      Fabricate(:user, trust_level: TrustLevel[0]).tap do |u|
-        u.user_profile.update(bio_raw: "I am batman")
-        UserAuthTokenLog.create!(client_ip: "127.0.0.1", action: "an_action", user: u)
-      end
-    DiscourseAkismet::UsersBouncer.new.move_to_state(user, "pending")
+      user =
+        Fabricate(:user, trust_level: TrustLevel[0]).tap do |u|
+          u.user_profile.update(bio_raw: "I am batman")
+          UserAuthTokenLog.create!(client_ip: "127.0.0.1", action: "an_action", user: u)
+        end
 
-    subject.execute({})
+      DiscourseAkismet::UsersBouncer.new.move_to_state(user, "pending")
 
-    expect(user.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
-      "confirmed_ham",
-    )
+      subject.execute({})
+
+      expect(user.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
+        expected_akismet_state,
+      )
+    end
+  end
+
+  context "with askimet" do
+    let(:client_name) { "Akismet::Client" }
+
+    before do
+      SiteSetting.akismet_api_key = "fake_key"
+      SiteSetting.anti_spam_service = "akismet"
+    end
+
+    context "with a spam user" do
+      let(:comment_check_result) { "spam" }
+      let(:expected_akismet_state) { "confirmed_spam" }
+
+      include_examples "check users"
+    end
+
+    context "with a non-spam user" do
+      let(:comment_check_result) { "ham" }
+      let(:expected_akismet_state) { "confirmed_ham" }
+
+      include_examples "check users"
+    end
+  end
+
+  context "with netease" do
+    let(:client_name) { "Netease::Client" }
+
+    before do
+      SiteSetting.anti_spam_service = "netease"
+      SiteSetting.netease_secret_id = "netease_id"
+      SiteSetting.netease_secret_key = "netease_key"
+      SiteSetting.netease_business_id = "business_id"
+    end
+
+    context "with a spam user" do
+      let(:comment_check_result) { "spam" }
+      let(:expected_akismet_state) { "confirmed_spam" }
+
+      include_examples "check users"
+    end
+
+    context "with a non-spam user" do
+      let(:comment_check_result) { "ham" }
+      let(:expected_akismet_state) { "confirmed_ham" }
+
+      include_examples "check users"
+    end
   end
 end

--- a/spec/lib/akismet_spec.rb
+++ b/spec/lib/akismet_spec.rb
@@ -3,15 +3,36 @@
 require "rails_helper"
 
 describe Akismet do
+  fab!(:user) { Fabricate(:active_user) }
+  fab!(:post) { Fabricate(:post) }
   let(:client) { Akismet::Client.new(api_key: "akismetkey", base_url: "someurl") }
+
+  let(:user_args) do
+    {
+      blog: Discourse.base_url,
+      content_type: "signup",
+      permalink: "#{Discourse.base_url}/u/#{user.username_lower}",
+      comment_author: user.username,
+      comment_content: user.user_profile&.bio_raw,
+      comment_author_url: nil,
+      user_ip: nil,
+      user_agent: nil,
+      comment_author_email: user.email,
+    }
+  end
 
   let(:post_args) do
     {
+      blog: Discourse.base_url,
       content_type: "forum-post",
-      permalink: "http://test.localhost/t/this-is-a-test-topic-49/1889/1",
-      comment_author: "bruce106",
-      comment_content: "This is a test topic 49\n\nHello world",
-      comment_author_email: "bruce106@wayne.com",
+      referrer: nil,
+      permalink: "#{Discourse.base_url}#{post.url}",
+      comment_author: post.user.username,
+      comment_content: "#{post.topic.title}\n\nHello world",
+      comment_author_url: nil,
+      user_ip: nil,
+      user_agent: nil,
+      comment_author_email: post.user.email,
     }
   end
 
@@ -98,6 +119,48 @@ describe Akismet do
       let(:feedback) { "ham" }
 
       it_behaves_like "sends feedback to Akismet and handles the response"
+    end
+  end
+
+  describe "request args" do
+    def args_for(target)
+      Akismet::RequestArgs.new(target)
+    end
+
+    shared_examples "args" do
+      it "generates args for user comment check" do
+        expect(args_for(user).for_check).to include(expected_user_args)
+      end
+
+      it "generates args for user feedback" do
+        expect(args_for(user).for_feedback).to include(expected_user_args)
+      end
+
+      it "generates args for post comment check" do
+        expect(args_for(post).for_check).to include(expected_post_args)
+      end
+
+      it "generates args for post feedback" do
+        expect(args_for(post).for_feedback).to include(expected_post_args)
+      end
+    end
+
+    context "with akismet_transmit_email true" do
+      before { SiteSetting.akismet_transmit_email = true }
+
+      include_examples "args" do
+        let(:expected_user_args) { user_args }
+        let(:expected_post_args) { post_args }
+      end
+    end
+
+    context "with akismet_transmit_email false" do
+      before { SiteSetting.akismet_transmit_email = false }
+
+      include_examples "args" do
+        let(:expected_user_args) { user_args.except(:comment_author_email) }
+        let(:expected_post_args) { post_args.except(:comment_author_email) }
+      end
     end
   end
 end

--- a/spec/lib/netease_spec.rb
+++ b/spec/lib/netease_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Netease do
+  let(:client) { Netease::Client.build_client }
+
+  let(:post_args) do
+    {
+      content_type: "forum-post",
+      permalink: "http://test.localhost/t/this-is-a-test-topic-49/1889/1",
+      comment_author: "bruce106",
+      comment_content: "This is a test topic 49\n\nHello world",
+      comment_author_email: "bruce106@wayne.com",
+    }
+  end
+
+  before do
+    SiteSetting.netease_secret_id = "secret_id"
+    SiteSetting.netease_secret_key = "secret_key"
+    SiteSetting.netease_business_id = "business_id"
+  end
+
+  describe "#comment_check" do
+    it "returns 'spam' spam posts" do
+      stub_request(:post, "http://as.dun.163.com/v5/text/check").to_return(
+        status: 200,
+        body: {
+          code: 200,
+          msg: "ok",
+          result: {
+            antispam: {
+              taskId: "fx6sxdcd89fvbvg4967b4787d78a",
+              dataId: "dataId",
+              suggestion: 1,
+            },
+          },
+        }.to_json,
+      )
+
+      expect(client.comment_check(post_args)).to eq("spam")
+    end
+
+    it "returns 'ham' non-spam posts" do
+      stub_request(:post, "http://as.dun.163.com/v5/text/check").to_return(
+        status: 200,
+        body: {
+          code: 200,
+          msg: "ok",
+          result: {
+            antispam: {
+              taskId: "fx6sxdcd89fvbvg4967b4787d78a",
+              dataId: "dataId",
+              suggestion: 0,
+            },
+          },
+        }.to_json,
+      )
+
+      expect(client.comment_check(post_args)).to eq("ham")
+    end
+
+    it "returns error details for error responses" do
+      stub_request(:post, "http://as.dun.163.com/v5/text/check").to_return(
+        status: 200,
+        body: { code: 401, msg: "Invalid business Id" }.to_json,
+      )
+
+      expect(client.comment_check(post_args)).to eq(
+        ["error", { code: 401, msg: "Invalid business Id" }],
+      )
+    end
+  end
+end

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -22,7 +22,7 @@ describe DiscourseAkismet::PostsBouncer do
 
   describe "#args_for" do
     it "should return args for a post" do
-      result = subject.args_for(post)
+      result = subject.args_for(post).for_check
       expect(result[:content_type]).to eq("forum-post")
       expect(result[:permalink]).to be_present
       expect(result[:comment_content]).to be_present
@@ -36,7 +36,7 @@ describe DiscourseAkismet::PostsBouncer do
 
     it "will omit email if the site setting is enabled" do
       SiteSetting.akismet_transmit_email = false
-      result = subject.args_for(post)
+      result = subject.args_for(post).for_check
       expect(result[:comment_author_email]).to be_blank
     end
 
@@ -45,7 +45,7 @@ describe DiscourseAkismet::PostsBouncer do
       PostDestroyer.new(Discourse.system_user, post).destroy
       deleted_post = Post.with_deleted.find(post.id)
 
-      result = subject.args_for(deleted_post)
+      result = subject.args_for(deleted_post).for_check
 
       expect(result[:comment_content]).to include(topic_title)
     end
@@ -61,12 +61,12 @@ describe DiscourseAkismet::PostsBouncer do
       end
 
       it "will munge the args before returning them" do
-        result = subject.args_for(post)
+        result = subject.args_for(post).for_check
         expect(result[:user_agent]).to be_blank
         expect(result[:comment_author]).to eq("CUSTOM: #{post.user.username}")
 
         described_class.reset_munge
-        result = subject.args_for(post)
+        result = subject.args_for(post).for_check
         expect(result[:user_agent]).to eq("Discourse Agent")
         expect(result[:comment_author]).to eq(post.user.username)
       end

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -21,54 +21,111 @@ describe DiscourseAkismet::PostsBouncer do
   let(:post) { Fabricate(:post) }
 
   describe "#args_for" do
-    it "should return args for a post" do
-      result = subject.args_for(post).for_check
-      expect(result[:content_type]).to eq("forum-post")
-      expect(result[:permalink]).to be_present
-      expect(result[:comment_content]).to be_present
-      expect(result[:user_ip]).to eq(@ip_address)
-      expect(result[:referrer]).to eq(@referrer)
-      expect(result[:user_agent]).to eq(@user_agent)
-      expect(result[:comment_author]).to eq(post.user.username)
-      expect(result[:comment_author_email]).to eq(post.user.email)
-      expect(result[:blog]).to eq(Discourse.base_url)
-    end
+    context "with akismet" do
+      before { SiteSetting.anti_spam_service = "akismet" }
 
-    it "will omit email if the site setting is enabled" do
-      SiteSetting.akismet_transmit_email = false
-      result = subject.args_for(post).for_check
-      expect(result[:comment_author_email]).to be_blank
-    end
-
-    it "works with deleted posts and topics" do
-      topic_title = post.topic.title
-      PostDestroyer.new(Discourse.system_user, post).destroy
-      deleted_post = Post.with_deleted.find(post.id)
-
-      result = subject.args_for(deleted_post).for_check
-
-      expect(result[:comment_content]).to include(topic_title)
-    end
-
-    describe "custom munge" do
-      after { described_class.reset_munge }
-
-      before do
-        described_class.munge_args do |args|
-          args[:comment_author] = "CUSTOM: #{args[:comment_author]}"
-          args.delete(:user_agent)
-        end
+      it "returns args for a post" do
+        result = subject.args_for(post, "check")
+        expect(result[:content_type]).to eq("forum-post")
+        expect(result[:permalink]).to be_present
+        expect(result[:comment_content]).to be_present
+        expect(result[:user_ip]).to eq(@ip_address)
+        expect(result[:referrer]).to eq(@referrer)
+        expect(result[:user_agent]).to eq(@user_agent)
+        expect(result[:comment_author]).to eq(post.user.username)
+        expect(result[:comment_author_email]).to eq(post.user.email)
+        expect(result[:blog]).to eq(Discourse.base_url)
       end
 
-      it "will munge the args before returning them" do
-        result = subject.args_for(post).for_check
-        expect(result[:user_agent]).to be_blank
-        expect(result[:comment_author]).to eq("CUSTOM: #{post.user.username}")
+      it "will omit email if the site setting is enabled" do
+        SiteSetting.akismet_transmit_email = false
+        result = subject.args_for(post, "check")
+        expect(result[:comment_author_email]).to be_blank
+      end
 
-        described_class.reset_munge
-        result = subject.args_for(post).for_check
-        expect(result[:user_agent]).to eq("Discourse Agent")
-        expect(result[:comment_author]).to eq(post.user.username)
+      it "works with deleted posts and topics" do
+        topic_title = post.topic.title
+        PostDestroyer.new(Discourse.system_user, post).destroy
+        deleted_post = Post.with_deleted.find(post.id)
+
+        result = subject.args_for(deleted_post, "check")
+
+        expect(result[:comment_content]).to include(topic_title)
+      end
+
+      context "with custom munge" do
+        after { described_class.reset_munge }
+
+        before do
+          described_class.munge_args do |args|
+            args[:comment_author] = "CUSTOM: #{args[:comment_author]}"
+            args.delete(:user_agent)
+          end
+        end
+
+        it "will munge the args before returning them" do
+          result = subject.args_for(post, "check")
+          expect(result[:user_agent]).to be_blank
+          expect(result[:comment_author]).to eq("CUSTOM: #{post.user.username}")
+
+          described_class.reset_munge
+          result = subject.args_for(post, "check")
+          expect(result[:user_agent]).to eq("Discourse Agent")
+          expect(result[:comment_author]).to eq(post.user.username)
+        end
+      end
+    end
+
+    context "with netease" do
+      before do
+        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
+      end
+
+      it "returns args for a post" do
+        result = subject.args_for(post, "check")
+        expect(result).to include(
+          dataId: "post-#{post.id}",
+          content: "#{post.topic.title}\n\nHello world",
+        )
+      end
+
+      it "omits email if the site setting is enabled" do
+        SiteSetting.akismet_transmit_email = false
+        result = subject.args_for(post, "check")
+
+        expect(result.values).not_to include(post.user.email)
+      end
+
+      it "returns args for deleted posts and topics" do
+        topic_title = post.topic.title
+        PostDestroyer.new(Discourse.system_user, post).destroy
+        deleted_post = Post.with_deleted.find(post.id)
+
+        result = subject.args_for(deleted_post, "check")
+
+        expect(result[:content]).to include(topic_title)
+      end
+
+      context "with custom munge" do
+        after { described_class.reset_munge }
+
+        before do
+          described_class.munge_args do |args|
+            args[:dataId] = "#{Discourse.current_hostname}-#{args[:dataId]}"
+          end
+        end
+
+        it "munges the args before returning them" do
+          result = subject.args_for(post, "check")
+          expect(result[:dataId]).to eq("#{Discourse.current_hostname}-post-#{post.id}")
+
+          described_class.reset_munge
+          result = subject.args_for(post, "check")
+          expect(result[:dataId]).to eq("post-#{post.id}")
+        end
       end
     end
   end
@@ -88,6 +145,7 @@ describe DiscourseAkismet::PostsBouncer do
       before { subject.move_to_state(post, "skipped") }
 
       it "keeps recent Akismet custom fields" do
+        post.upsert_custom_fields("NETEASE_TASK_ID" => "task_id_123")
         subject.clean_old_akismet_custom_fields
 
         post.reload
@@ -113,75 +171,134 @@ describe DiscourseAkismet::PostsBouncer do
 
     before { subject.move_to_state(post, "pending") }
 
-    it "Creates a new ReviewableAkismetPost when spam is confirmed by Akismet" do
-      stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
-        status: 200,
-        body: "true",
-      )
+    shared_examples "successful post checks" do
+      it "creates a new ReviewableAkismetPost when spam is confirmed by Akismet" do
+        subject.perform_check(client, post)
+        reviewable_akismet_post = ReviewableAkismetPost.last
 
-      subject.perform_check(client, post)
-      reviewable_akismet_post = ReviewableAkismetPost.last
+        expect(reviewable_akismet_post).to be_pending
+        expect(reviewable_akismet_post.post).to eq post
+        expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
+        expect(reviewable_akismet_post.payload["post_cooked"]).to eq post.cooked
 
-      expect(reviewable_akismet_post).to be_pending
-      expect(reviewable_akismet_post.post).to eq post
-      expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
-      expect(reviewable_akismet_post.payload["post_cooked"]).to eq post.cooked
+        # notifies user that post is hidden and includes post URL
+        expect(Post.last.raw).to include(post.full_url)
+        expect(Post.last.raw).to include(post.topic.title)
+      end
 
-      # notifies user that post is hidden and includes post URL
-      expect(Post.last.raw).to include(post.full_url)
-      expect(Post.last.raw).to include(post.topic.title)
+      it "creates a new score for the new reviewable" do
+        subject.perform_check(client, post)
+        reviewable_akismet_score = ReviewableScore.last
+
+        expect(reviewable_akismet_score.user).to eq Discourse.system_user
+        expect(reviewable_akismet_score.reviewable_score_type).to eq PostActionType.types[:spam]
+        expect(reviewable_akismet_score.take_action_bonus).to be_zero
+      end
+
+      it "publishes a message to display a banner on the topic page" do
+        channel = [described_class::TOPIC_DELETED_CHANNEL, post.topic_id].join
+        message = MessageBus.track_publish(channel) { subject.perform_check(client, post) }.first
+
+        data = message.data
+
+        expect(data).to eq("spam_found")
+      end
     end
 
-    it "Creates a new score for the new reviewable" do
-      stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
-        status: 200,
-        body: "true",
-      )
+    context "with akismet success reponse" do
+      before do
+        SiteSetting.anti_spam_service = "akismet"
+        stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
+          status: 200,
+          body: "true",
+        )
+      end
 
-      subject.perform_check(client, post)
-      reviewable_akismet_score = ReviewableScore.last
-
-      expect(reviewable_akismet_score.user).to eq Discourse.system_user
-      expect(reviewable_akismet_score.reviewable_score_type).to eq PostActionType.types[:spam]
-      expect(reviewable_akismet_score.take_action_bonus).to be_zero
+      include_examples "successful post checks"
     end
 
-    it "publishes a message to display a banner on the topic page" do
-      stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
-        status: 200,
-        body: "true",
-      )
+    context "with neteaase success response" do
+      before do
+        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
 
-      channel = [described_class::TOPIC_DELETED_CHANNEL, post.topic_id].join
-      message = MessageBus.track_publish(channel) { subject.perform_check(client, post) }.first
+        stub_request(:post, "http://as.dun.163.com/v5/text/check").to_return(
+          status: 200,
+          body: {
+            code: 200,
+            msg: "ok",
+            result: {
+              antispam: {
+                taskId: "fx6sxdcd89fvbvg4967b4787d78a",
+                dataId: "dataId",
+                suggestion: 1,
+              },
+            },
+          }.to_json,
+        )
+      end
 
-      data = message.data
-
-      expect(data).to eq("spam_found")
+      include_examples "successful post checks"
     end
 
-    it "Creates a new ReviewableAkismetPost when an API error is returned" do
-      subject.move_to_state(post, "pending")
+    context "with akismet API error" do
+      before do
+        stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
+          status: 200,
+          body: "false",
+          headers: {
+            "X-akismet-error" => "status",
+            "X-akismet-alert-code" => "123",
+            "X-akismet-alert-msg" => "An alert message",
+          },
+        )
+      end
 
-      stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
-        status: 200,
-        body: "false",
-        headers: {
-          "X-akismet-error" => "status",
-          "X-akismet-alert-code" => "123",
-          "X-akismet-alert-msg" => "An alert message",
-        },
-      )
+      it "creates a new ReviewableAkismetPost when an API error is returned" do
+        subject.move_to_state(post, "pending")
+        subject.perform_check(client, post)
+        reviewable_akismet_post = ReviewableAkismetPost.last
 
-      subject.perform_check(client, post)
-      reviewable_akismet_post = ReviewableAkismetPost.last
+        expect(reviewable_akismet_post).to be_pending
+        expect(reviewable_akismet_post.post).to eq post
+        expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
+        expect(reviewable_akismet_post.payload["external_error"]["error"]).to eq("status")
+        expect(reviewable_akismet_post.payload["external_error"]["code"]).to eq("123")
+        expect(reviewable_akismet_post.payload["external_error"]["msg"]).to eq("An alert message")
+      end
+    end
 
-      expect(reviewable_akismet_post).to be_pending
-      expect(reviewable_akismet_post.post).to eq post
-      expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
-      expect(reviewable_akismet_post.payload["external_error"]["error"]).to eq("status")
-      expect(reviewable_akismet_post.payload["external_error"]["code"]).to eq("123")
-      expect(reviewable_akismet_post.payload["external_error"]["msg"]).to eq("An alert message")
+    context "with netease API error" do
+      before do
+        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
+
+        stub_request(:post, "http://as.dun.163.com/v5/text/check").to_return(
+          status: 200,
+          body: { code: 400, msg: "Missing SecretId or businessId" }.to_json,
+        )
+      end
+
+      it "creates a new ReviewableAkismetPost when an API error is returned" do
+        subject.move_to_state(post, "pending")
+        subject.perform_check(client, post)
+        reviewable_akismet_post = ReviewableAkismetPost.last
+
+        expect(reviewable_akismet_post).to be_pending
+        expect(reviewable_akismet_post.post).to eq post
+        expect(reviewable_akismet_post.reviewable_by_moderator).to eq true
+        expect(reviewable_akismet_post.payload["external_error"]["error"]).to eq(
+          "Missing SecretId or businessId",
+        )
+        expect(reviewable_akismet_post.payload["external_error"]["code"]).to eq("400")
+        expect(reviewable_akismet_post.payload["external_error"]["msg"]).to eq(
+          "Missing SecretId or businessId",
+        )
+      end
     end
   end
 

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -109,7 +109,7 @@ describe DiscourseAkismet::PostsBouncer do
   end
 
   describe "#check_post" do
-    let(:client) { Akismet::Client.build_client }
+    let(:client) { DiscourseAkismet::AntiSpamService.client }
 
     before { subject.move_to_state(post, "pending") }
 

--- a/spec/lib/users_bouncer_spec.rb
+++ b/spec/lib/users_bouncer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
       profile = user.user_profile
       token = user.user_auth_token_logs.last
 
-      result = subject.args_for(user)
+      result = subject.args_for(user).for_check
       expect(result[:content_type]).to eq("signup")
       expect(result[:permalink]).to eq("#{Discourse.base_url}/u/#{user.username_lower}")
       expect(result[:comment_author]).to eq(user.username)

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -105,7 +105,10 @@ describe Plugin::Instance do
     # Create the post and immediately destroy it, but leave the job running
     post = post_creator.create
     PostDestroyer.new(post.user, post).destroy
-    DiscourseAkismet::PostsBouncer.new.perform_check(Akismet::Client.build_client, post.reload)
+    DiscourseAkismet::PostsBouncer.new.perform_check(
+      DiscourseAkismet::AntiSpamService.client,
+      post.reload,
+    )
     expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq("skipped")
 
     # Check the recovered post because it was not checked the first itme


### PR DESCRIPTION
As its name suggests,  the plugin only supports Akismet for automated spam detection.

This change adds support for the text detection service offered by NetEase. Along with a host of other site settings for NetEase API credentials, this PR also introduces an `anti_spam_service` site setting for switching between Akismet(default value) and NetEase. 

Most of the Akismet specific references have been intentionally left intact in this first iteration. 

<img width="874" alt="Screenshot 2023-02-07 at 2 52 26 AM" src="https://user-images.githubusercontent.com/849886/217136019-77d99739-2b9d-4ace-8089-c5dc4020e487.png">


