### PR TITLE
DEV: Remove unused string

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7,7 +7,7 @@ en:
             confirmed_ham: "Not spam"
             confirmed_spam: "Confirm spam"
             confirmed_spam_deleted: "Confirm spam and delete user"
-            dismissed: "Dismiss spam"
+            ignored: "Ignore spam"
       akismet_api_error: "Akismet API Error:"
 
     akismet:


### PR DESCRIPTION
This string isn't needed anymore since 56fc3bd962bd19b628b9a1f0fda2bbb6e47bb207 and it also reverts the changes from fed13ef4051ab9d0432f4227d81674c79a0bbdce which removed the wrong string by accident.