### PR TITLE
DEV: Make batched spam post/user job run frequency configurable

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,4 +31,7 @@ plugins:
     default: false
   review_tl1_users_first_post:
     default: true
+  spam_check_interval_mins:
+    default: 10
+    hidden: true
 

--- a/jobs/scheduled/check_for_spam_posts.rb
+++ b/jobs/scheduled/check_for_spam_posts.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class CheckForSpamPosts < ::Jobs::Scheduled
-    every 10.minutes
+    every SiteSetting.spam_check_interval_mins.minutes
 
     def execute(args)
       return unless SiteSetting.akismet_enabled?

--- a/jobs/scheduled/check_for_spam_users.rb
+++ b/jobs/scheduled/check_for_spam_users.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class CheckForSpamUsers < ::Jobs::Scheduled
-    every 10.minutes
+    every SiteSetting.spam_check_interval_mins.minutes
 
     def execute(args)
       return unless SiteSetting.akismet_enabled?


### PR DESCRIPTION
This change allows the frequency at which post/user spam checking jobs run to be configurable via a hidden site setting.

The new site setting defaults to 10 minutes to maintain backward compatibility with the existing hardcoded implementation.