### PR TITLE
DEV: Indicate NetEase provider is Chinese only

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,7 +7,7 @@ plugins:
     type: enum
     choices:
       - akismet
-      - netease
+      - netease (Chinese)
   akismet_api_key:
     default: ""
     shadowed_by_global: true

--- a/db/migrate/20230321160450_update_netease_site_setting_value.rb
+++ b/db/migrate/20230321160450_update_netease_site_setting_value.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateNeteaseSiteSettingValue < ActiveRecord::Migration[7.0]
+  def up
+    execute "UPDATE site_settings SET value = 'netease (Chinese)' WHERE name = 'anti_spam_service' AND value = 'netease'"
+  end
+
+  def down
+    execute "UPDATE site_settings SET value = 'netease' WHERE name = 'anti_spam_service' AND value = 'netease (Chinese)'"
+  end
+end

--- a/lib/discourse_akismet/anti_spam_service.rb
+++ b/lib/discourse_akismet/anti_spam_service.rb
@@ -2,6 +2,9 @@
 
 module DiscourseAkismet
   class AntiSpamService
+    NETEASE = "netease (Chinese)"
+    AKISMET = "akismet"
+
     def self.client
       return if !SiteSetting.akismet_enabled?
 
@@ -26,7 +29,7 @@ module DiscourseAkismet
     end
 
     def self.netease?
-      SiteSetting.anti_spam_service == "netease"
+      SiteSetting.anti_spam_service == NETEASE
     end
   end
 end

--- a/spec/jobs/regular/check_akismet_post_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Jobs::CheckAkismetPost do
 
     context "with akismet" do
       before do
-        SiteSetting.anti_spam_service = "akismet"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
         SiteSetting.akismet_api_key = "fake_key"
         DiscourseAkismet::PostsBouncer.new.move_to_state(post, "pending")
       end
@@ -68,7 +68,7 @@ RSpec.describe Jobs::CheckAkismetPost do
 
     context "with netease" do
       before do
-        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"

--- a/spec/jobs/scheduled/check_for_spam_users_spec.rb
+++ b/spec/jobs/scheduled/check_for_spam_users_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Jobs::CheckForSpamUsers do
 
     before do
       SiteSetting.akismet_api_key = "fake_key"
-      SiteSetting.anti_spam_service = "akismet"
+      SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
     end
 
     context "with a spam user" do
@@ -59,7 +59,7 @@ RSpec.describe Jobs::CheckForSpamUsers do
     let(:client_name) { "Netease::Client" }
 
     before do
-      SiteSetting.anti_spam_service = "netease"
+      SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
       SiteSetting.netease_secret_id = "netease_id"
       SiteSetting.netease_secret_key = "netease_key"
       SiteSetting.netease_business_id = "business_id"

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -22,7 +22,7 @@ describe DiscourseAkismet::PostsBouncer do
 
   describe "#args_for" do
     context "with akismet" do
-      before { SiteSetting.anti_spam_service = "akismet" }
+      before { SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET }
 
       it "returns args for a post" do
         result = subject.args_for(post, "check")
@@ -78,7 +78,7 @@ describe DiscourseAkismet::PostsBouncer do
 
     context "with netease" do
       before do
-        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"
@@ -207,7 +207,7 @@ describe DiscourseAkismet::PostsBouncer do
 
     context "with akismet success reponse" do
       before do
-        SiteSetting.anti_spam_service = "akismet"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
         stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
           status: 200,
           body: "true",
@@ -219,7 +219,7 @@ describe DiscourseAkismet::PostsBouncer do
 
     context "with neteaase success response" do
       before do
-        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"
@@ -272,7 +272,7 @@ describe DiscourseAkismet::PostsBouncer do
 
     context "with netease API error" do
       before do
-        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"

--- a/spec/lib/users_bouncer_spec.rb
+++ b/spec/lib/users_bouncer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
 
   describe "#args_for" do
     context "with akismet" do
-      before { SiteSetting.anti_spam_service = "akismet" }
+      before { SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET }
 
       it "returns args for a user" do
         profile = user.user_profile
@@ -40,7 +40,7 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
 
     context "with netease" do
       before do
-        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"
@@ -171,7 +171,7 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
     context "with akismet" do
       let(:client_name) { "Akismet::Client" }
 
-      before { SiteSetting.anti_spam_service = "akismet" }
+      before { SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET }
 
       include_examples "reviewables"
     end
@@ -179,7 +179,7 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
     context "with netease" do
       let(:client_name) { "Netease::Client" }
       before do
-        SiteSetting.anti_spam_service = "netease"
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -146,7 +146,7 @@ describe Plugin::Instance do
 
   context "with akismet" do
     before do
-      SiteSetting.anti_spam_service = "akismet"
+      SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
       SiteSetting.akismet_api_key = "akismetkey"
     end
 
@@ -176,7 +176,7 @@ describe Plugin::Instance do
 
   context "with netease" do
     before do
-      SiteSetting.anti_spam_service = "netease"
+      SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
       SiteSetting.netease_secret_id = "netease_id"
       SiteSetting.netease_secret_key = "netease_key"
       SiteSetting.netease_business_id = "business_id"


### PR DESCRIPTION
This change aims to help reduce/prevent confusion with the NetEase provider which is a china-based service targeted towards chinese content.