### PR TITLE
FEATURE: add comment_date_gmt for additional signal

### DIFF
--- a/lib/akismet.rb
+++ b/lib/akismet.rb
@@ -35,6 +35,7 @@ class Akismet
         comment_author_url: profile&.website,
         user_ip: token&.client_ip&.to_s,
         user_agent: token&.user_agent,
+        comment_date_gmt: @target.created_at.iso8601,
       }
 
       # Sending the email to akismet is optional
@@ -55,6 +56,7 @@ class Akismet
         comment_author_url: @target.user&.user_profile&.website,
         user_ip: @target.custom_fields["AKISMET_IP_ADDRESS"],
         user_agent: @target.custom_fields["AKISMET_USER_AGENT"],
+        comment_date_gmt: @target.created_at.iso8601,
       }
 
       # Sending the email to akismet is optional

--- a/spec/lib/akismet_spec.rb
+++ b/spec/lib/akismet_spec.rb
@@ -18,6 +18,7 @@ describe Akismet do
       user_ip: nil,
       user_agent: nil,
       comment_author_email: user.email,
+      comment_date_gmt: user.created_at.iso8601,
     }
   end
 
@@ -33,6 +34,7 @@ describe Akismet do
       user_ip: nil,
       user_agent: nil,
       comment_author_email: post.user.email,
+      comment_date_gmt: post.created_at.iso8601,
     }
   end
 


### PR DESCRIPTION
Akismet can use the date of the comment as extra signal for spam checking

Add it.
