### PR TITLE
DEV: Only queue post checks if actual content changed

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -114,10 +114,14 @@ after_initialize do
     end
   end
 
-  on(:post_edited) do |post, _, _|
-    bouncer = DiscourseAkismet::PostsBouncer.new
+  on(:post_edited) do |post, _, revisor|
+    next unless revisor.reviewable_content_changed?
 
-    check_post(bouncer, post) if post.last_editor.regular? && bouncer.should_check?(post)
+    editor = post.last_editor
+    next if editor.is_system_user? || !editor.regular?
+
+    bouncer = DiscourseAkismet::PostsBouncer.new
+    check_post(bouncer, post) if bouncer.should_check?(post)
   end
 
   on(:post_recovered) do |post, _, _|


### PR DESCRIPTION
Currently, post metadata changes cause spam service rechecks, this isn't ideal since it leads to rechecking the same content multiple times.

This change skips the spam service check if the revision was performed by a system user and/or has no topic `title` and/or `raw` changes.