### PR TITLE
FIX: delete reviewable when posts are deleted by user destroyer class.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -72,6 +72,8 @@ after_initialize do
                 reviewable.perform(guardian.user, :confirm_spam)
               end
             end
+        elsif opts[:delete_posts]
+          ReviewableAkismetPost.where(target_created_by: user).destroy_all
         end
       end,
     )

--- a/spec/lib/user_destroyer_spec.rb
+++ b/spec/lib/user_destroyer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserDestroyer do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:post) { Fabricate(:post, user_id: user.id) }
+  fab!(:reviewable) { Fabricate(:reviewable_akismet_post, target_created_by: user, target: post) }
+
+  before do
+    SiteSetting.akismet_api_key = "akismetkey"
+    SiteSetting.akismet_enabled = true
+  end
+
+  it "deletes reviewable when the `delete_posts` flag is enabled" do
+    described_class.new(admin).destroy(user, delete_posts: true)
+    expect { reviewable.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -38,14 +38,6 @@ describe Plugin::Instance do
     Jobs::CheckAkismetPost.clear
   end
 
-  it "destroys reviewable when post is deleted by user destroyer class" do
-    post = Fabricate(:post)
-    reviewable = ReviewableAkismetPost.new(target: post)
-    UserDestroyer.new(admin).destroy(post.user, delete_posts: true)
-
-    expect { reviewable.reload }.to raise_error(ActiveRecord::RecordNotFound)
-  end
-
   it "does not queue edited post with no content changes" do
     post = user_tl0_post_creator.create
     expect_user_tl0_post_to_be_queued(post)

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -38,6 +38,14 @@ describe Plugin::Instance do
     Jobs::CheckAkismetPost.clear
   end
 
+  it "destroys reviewable when post is deleted by user destroyer class" do
+    post = Fabricate(:post)
+    reviewable = ReviewableAkismetPost.new(target: post)
+    UserDestroyer.new(admin).destroy(post.user, delete_posts: true)
+
+    expect { reviewable.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
   it "does not queue edited post with no content changes" do
     post = user_tl0_post_creator.create
     expect_user_tl0_post_to_be_queued(post)


### PR DESCRIPTION
Previously, when a user self-deleted their account the reviewable is not removed. So, if it is marked as not spam the post is recovered and the system user becomes the author of the recovered post.