### PR TITLE
DEV: Resolve computed-property-override deprecation

### DIFF
--- a/assets/javascripts/discourse-akismet/connectors/flag-modal-bottom/akismet-status.js
+++ b/assets/javascripts/discourse-akismet/connectors/flag-modal-bottom/akismet-status.js
@@ -1,5 +1,0 @@
-export default {
-  setupComponent(args, component) {
-    component.set("post", args.post);
-  },
-};


### PR DESCRIPTION
Discourse core already sets up computed properties on connector components for each of the arguments. Overriding it here leads to an error in recent ember versions.