### PR TITLE
DEV: Replace deprecated min_trust_to_create_post

### DIFF
--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 describe Plugin::Instance do
-  fab!(:user_tl0) { Fabricate(:user, trust_level: TrustLevel[0]) }
-  fab!(:user_tl1) { Fabricate(:user, trust_level: TrustLevel[1]) }
+  fab!(:user_tl0) { Fabricate(:user, trust_level: TrustLevel[0], refresh_auto_groups: true) }
+  fab!(:user_tl1) { Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true) }
   fab!(:admin) { Fabricate(:admin) }
   let(:post_params) do
     { raw: "this is the new content for my topic", title: "this is my new topic title" }


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/24740, `min_trust_to_create_topic` site setting was replaced by `create_topic_allowed_groups`. This PR replaces the former, deprecated one, with the latter.