### PR TITLE
FEATURE: Implement Akismet flag and review system for PostVotingComments

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,0 +1,7 @@
+{
+    "tests": {
+      "requiredPlugins": [
+        "https://github.com/discourse/discourse-post-voting"
+      ]
+    }
+  }

--- a/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.hbs
+++ b/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.hbs
@@ -1,0 +1,34 @@
+<div class="post-topic">
+  <a class="title-text" href={{this.post.url}}>
+    {{html-safe @reviewable.topic.fancyTitle}}</a>
+  {{category-badge @reviewable.category}}
+</div>
+
+<div class="post-contents-wrapper">
+  <ReviewableCreatedBy @user={{@reviewable.target_created_by}} @tagName="" />
+  <div class="post-contents">
+    <ReviewablePostHeader
+      @reviewable={{@reviewable}}
+      @createdBy={{@reviewable.target_created_by}}
+      @tagName=""
+    />
+
+    <div class="post-body">
+      {{html-safe (or @reviewable.payload.comment_cooked @reviewable.cooked)}}
+    </div>
+
+    {{#if @reviewable.payload.transcript_topic_id}}
+      <div class="transcript">
+        <LinkTo
+          @route="topic"
+          @models={{array "-" @reviewable.payload.transcript_topic_id}}
+          class="btn btn-small"
+        >
+          {{i18n "review.transcript.view"}}
+        </LinkTo>
+      </div>
+    {{/if}}
+
+    {{yield}}
+  </div>
+</div>

--- a/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.js
+++ b/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.js
@@ -11,6 +11,6 @@ export default class ReviewableAkismetPostVotingComment extends Component {
     this.fetchPost();
   }
   async fetchPost() {
-    this.post = await this.store.find("post", this.args.reviewable.post_id);;
+    this.post = await this.store.find("post", this.args.reviewable.post_id);
   }
 }

--- a/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.js
+++ b/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.js
@@ -1,0 +1,17 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { inject as service } from "@ember/service";
+
+export default class ReviewableAkismetPostVotingComment extends Component {
+  @service store;
+  @tracked post;
+
+  constructor() {
+    super(...arguments);
+    this.fetchPost();
+  }
+  async fetchPost() {
+    const post = await this.store.find("post", this.args.reviewable.post_id);
+    this.post = post;
+  }
+}

--- a/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.js
+++ b/assets/javascripts/discourse/components/reviewable-akismet-post-voting-comment.js
@@ -11,7 +11,6 @@ export default class ReviewableAkismetPostVotingComment extends Component {
     this.fetchPost();
   }
   async fetchPost() {
-    const post = await this.store.find("post", this.args.reviewable.post_id);
-    this.post = post;
+    this.post = await this.store.find("post", this.args.reviewable.post_id);;
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -51,4 +51,3 @@ en:
         reviewable_akismet_post_voting_comment:
           title: "Akismet Flagged Post Voting Comment"
        
-          

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -48,3 +48,7 @@ en:
           title: "Akismet Flagged Post"
         reviewable_akismet_user:
           title: "Akismet Flagged User"
+        reviewable_akismet_post_voting_comment:
+          title: "Akismet Flagged Post Voting Comment"
+       
+          

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,6 +31,8 @@ discourse_akismet:
     default: false
   review_tl1_users_first_post:
     default: true
+  review_tl1_users_first_post_voting_comment:
+    default: true
   spam_check_interval_mins:
     default: 10
     hidden: true

--- a/jobs/regular/check_akismet_post.rb
+++ b/jobs/regular/check_akismet_post.rb
@@ -8,7 +8,8 @@ module Jobs
       return if Reviewable.exists?(target: post)
 
       DistributedMutex.synchronize("akismet_post_#{post.id}") do
-        if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
+        if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] ==
+             DiscourseAkismet::Bouncer::PENDING_STATE
           DiscourseAkismet::PostsBouncer.new.perform_check(
             DiscourseAkismet::AntiSpamService.client,
             post,

--- a/jobs/regular/check_akismet_post.rb
+++ b/jobs/regular/check_akismet_post.rb
@@ -3,12 +3,12 @@
 module Jobs
   class CheckAkismetPost < ::Jobs::Base
     def execute(args)
-      return unless SiteSetting.akismet_enabled?
-      return unless post = Post.find_by(id: args[:post_id], user_deleted: false)
+      return if !SiteSetting.akismet_enabled?
+      return if !(post = Post.find_by(id: args[:post_id], user_deleted: false))
       return if Reviewable.exists?(target: post)
 
       DistributedMutex.synchronize("akismet_post_#{post.id}") do
-        if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+        if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
           DiscourseAkismet::PostsBouncer.new.perform_check(
             DiscourseAkismet::AntiSpamService.client,
             post,

--- a/jobs/regular/check_akismet_post_voting_comment.rb
+++ b/jobs/regular/check_akismet_post_voting_comment.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CheckAkismetPostVotingComment < ::Jobs::Base
+    def execute(args)
+      return unless SiteSetting.akismet_enabled?
+      return unless comment = PostVotingComment.find_by(id: args[:comment_id])
+      return if Reviewable.exists?(target: comment)
+
+      DistributedMutex.synchronize("akismet_post_#{comment.id}") do
+        if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+          DiscourseAkismet::PostVotingCommentsBouncer.new.perform_check(
+            DiscourseAkismet::AntiSpamService.client,
+            comment,
+          )
+        end
+      end
+    end
+  end
+end

--- a/jobs/regular/check_akismet_post_voting_comment.rb
+++ b/jobs/regular/check_akismet_post_voting_comment.rb
@@ -8,7 +8,8 @@ module Jobs
       return if Reviewable.exists?(target: comment)
 
       DistributedMutex.synchronize("akismet_post_voting_comment_#{comment.id}") do
-        if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
+        if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] ==
+             DiscourseAkismet::Bouncer::PENDING_STATE
           DiscourseAkismet::PostVotingCommentsBouncer.new.perform_check(
             DiscourseAkismet::AntiSpamService.client,
             comment,

--- a/jobs/regular/check_akismet_post_voting_comment.rb
+++ b/jobs/regular/check_akismet_post_voting_comment.rb
@@ -7,7 +7,7 @@ module Jobs
       return unless comment = PostVotingComment.find_by(id: args[:comment_id])
       return if Reviewable.exists?(target: comment)
 
-      DistributedMutex.synchronize("akismet_post_#{comment.id}") do
+      DistributedMutex.synchronize("akismet_post_voting_comment_#{comment.id}") do
         if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
           DiscourseAkismet::PostVotingCommentsBouncer.new.perform_check(
             DiscourseAkismet::AntiSpamService.client,

--- a/jobs/regular/check_akismet_post_voting_comment.rb
+++ b/jobs/regular/check_akismet_post_voting_comment.rb
@@ -3,12 +3,12 @@
 module Jobs
   class CheckAkismetPostVotingComment < ::Jobs::Base
     def execute(args)
-      return unless SiteSetting.akismet_enabled?
-      return unless comment = PostVotingComment.find_by(id: args[:comment_id])
+      return if !SiteSetting.akismet_enabled?
+      return if !(comment = PostVotingComment.find_by(id: args[:comment_id]))
       return if Reviewable.exists?(target: comment)
 
       DistributedMutex.synchronize("akismet_post_voting_comment_#{comment.id}") do
-        if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+        if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
           DiscourseAkismet::PostVotingCommentsBouncer.new.perform_check(
             DiscourseAkismet::AntiSpamService.client,
             comment,

--- a/jobs/regular/check_akismet_user.rb
+++ b/jobs/regular/check_akismet_user.rb
@@ -8,7 +8,8 @@ module Jobs
       return if Reviewable.exists?(target: user)
 
       DistributedMutex.synchronize("akismet_user_#{user.id}") do
-        if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
+        if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] ==
+             DiscourseAkismet::Bouncer::PENDING_STATE
           DiscourseAkismet::UsersBouncer.new.perform_check(
             DiscourseAkismet::AntiSpamService.client,
             user,

--- a/jobs/regular/check_akismet_user.rb
+++ b/jobs/regular/check_akismet_user.rb
@@ -3,12 +3,12 @@
 module Jobs
   class CheckAkismetUser < ::Jobs::Base
     def execute(args)
-      return unless SiteSetting.akismet_enabled?
-      return unless user = User.includes(:user_profile).find_by(id: args[:user_id])
+      return if !SiteSetting.akismet_enabled?
+      return if !(user = User.includes(:user_profile).find_by(id: args[:user_id]))
       return if Reviewable.exists?(target: user)
 
       DistributedMutex.synchronize("akismet_user_#{user.id}") do
-        if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+        if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
           DiscourseAkismet::UsersBouncer.new.perform_check(
             DiscourseAkismet::AntiSpamService.client,
             user,

--- a/jobs/scheduled/check_for_spam_post_voting_comments.rb
+++ b/jobs/scheduled/check_for_spam_post_voting_comments.rb
@@ -17,7 +17,8 @@ module Jobs
         .where(deleted_at: nil)
         .find_each do |comment|
           DistributedMutex.synchronize("akismet_post_voting_comment_#{comment.id}") do
-            if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
+            if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] ==
+                 DiscourseAkismet::Bouncer::PENDING_STATE
               spam_count += 1 if bouncer.perform_check(client, comment)
             end
           end

--- a/jobs/scheduled/check_for_spam_post_voting_comments.rb
+++ b/jobs/scheduled/check_for_spam_post_voting_comments.rb
@@ -17,7 +17,7 @@ module Jobs
         .where(deleted_at: nil)
         .find_each do |comment|
           DistributedMutex.synchronize("akismet_post_voting_comment_#{comment.id}") do
-            if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+            if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
               spam_count += 1 if bouncer.perform_check(client, comment)
             end
           end

--- a/jobs/scheduled/check_for_spam_post_voting_comments.rb
+++ b/jobs/scheduled/check_for_spam_post_voting_comments.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CheckForSpamPostsVotingComments < ::Jobs::Scheduled
+    every SiteSetting.spam_check_interval_mins.minutes
+
+    def execute(args)
+      return unless SiteSetting.akismet_enabled?
+      return if DiscourseAkismet::AntiSpamService.api_secret_blank?
+
+      bouncer = DiscourseAkismet::PostVotingCommentsBouncer.new
+      client = DiscourseAkismet::AntiSpamService.client
+      spam_count = 0
+
+      DiscourseAkismet::PostVotingCommentsBouncer
+        .to_check
+        .where(deleted_at: nil)
+        .find_each do |comment|
+          DistributedMutex.synchronize("akismet_post_voting_comment_#{comment.id}") do
+            if comment.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+              spam_count += 1 if bouncer.perform_check(client, comment)
+            end
+          end
+        end
+
+      # Trigger an event that akismet found spam. This allows people to
+      # notify chat rooms or whatnot
+      DiscourseEvent.trigger(:akismet_found_spam, spam_count) if spam_count > 0
+    end
+  end
+end

--- a/jobs/scheduled/check_for_spam_posts.rb
+++ b/jobs/scheduled/check_for_spam_posts.rb
@@ -17,7 +17,7 @@ module Jobs
         .where(user_deleted: false)
         .find_each do |post|
           DistributedMutex.synchronize("akismet_post_#{post.id}") do
-            if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+            if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
               spam_count += 1 if bouncer.perform_check(client, post)
             end
           end

--- a/jobs/scheduled/check_for_spam_posts.rb
+++ b/jobs/scheduled/check_for_spam_posts.rb
@@ -17,7 +17,8 @@ module Jobs
         .where(user_deleted: false)
         .find_each do |post|
           DistributedMutex.synchronize("akismet_post_#{post.id}") do
-            if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
+            if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] ==
+                 DiscourseAkismet::Bouncer::PENDING_STATE
               spam_count += 1 if bouncer.perform_check(client, post)
             end
           end

--- a/jobs/scheduled/check_for_spam_users.rb
+++ b/jobs/scheduled/check_for_spam_users.rb
@@ -16,7 +16,7 @@ module Jobs
         .includes(:user_profile)
         .find_each do |user|
           DistributedMutex.synchronize("akismet_user_#{user.id}") do
-            if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == "pending"
+            if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
               bouncer.perform_check(client, user)
             end
           end

--- a/jobs/scheduled/check_for_spam_users.rb
+++ b/jobs/scheduled/check_for_spam_users.rb
@@ -16,7 +16,8 @@ module Jobs
         .includes(:user_profile)
         .find_each do |user|
           DistributedMutex.synchronize("akismet_user_#{user.id}") do
-            if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] == DiscourseAkismet::Bouncer::PENDING_STATE
+            if user.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] ==
+                 DiscourseAkismet::Bouncer::PENDING_STATE
               bouncer.perform_check(client, user)
             end
           end

--- a/lib/akismet.rb
+++ b/lib/akismet.rb
@@ -105,7 +105,7 @@ class Akismet
 
     def post_voting_comment_content
       return if !@target.is_a?(PostVotingComment)
-      return @target.raw
+      @target.raw
     end
   end
 

--- a/lib/akismet.rb
+++ b/lib/akismet.rb
@@ -92,7 +92,7 @@ class Akismet
     end
 
     def target_name
-      @target.class.to_s.split(/(?=[A-Z])/).join("_").downcase
+      @target.class.to_s.underscore
     end
 
     def post_content

--- a/lib/discourse_akismet/bouncer.rb
+++ b/lib/discourse_akismet/bouncer.rb
@@ -24,7 +24,6 @@ module DiscourseAkismet
 
     def perform_check(client, target)
       pre_check_passed = before_check(target)
-
       if pre_check_passed
         args = args_for(target, "check")
         client

--- a/lib/discourse_akismet/bouncer.rb
+++ b/lib/discourse_akismet/bouncer.rb
@@ -25,7 +25,6 @@ module DiscourseAkismet
     end
 
     def perform_check(client, target)
-      byebug
       pre_check_passed = before_check(target)
       if pre_check_passed
         args = args_for(target, "check")

--- a/lib/discourse_akismet/post_voting_comments_bouncer.rb
+++ b/lib/discourse_akismet/post_voting_comments_bouncer.rb
@@ -113,8 +113,7 @@ module DiscourseAkismet
     end
 
     def before_check(comment)
-      return true unless comment.post.nil?
-      false
+      comment.post.present?
     end
 
     def mark_as_spam(comment)

--- a/lib/discourse_akismet/post_voting_comments_bouncer.rb
+++ b/lib/discourse_akismet/post_voting_comments_bouncer.rb
@@ -22,7 +22,10 @@ module DiscourseAkismet
           "LEFT OUTER JOIN reviewables ON reviewables.target_id = post_voting_comment_custom_fields.post_voting_comment_id",
         )
         .where("post_voting_comment_custom_fields.name = ?", AKISMET_STATE)
-        .where("post_voting_comment_custom_fields.value = ?", DiscourseAkismet::Bouncer::PENDING_STATE)
+        .where(
+          "post_voting_comment_custom_fields.value = ?",
+          DiscourseAkismet::Bouncer::PENDING_STATE,
+        )
         .where("reviewables.id IS NULL")
         .includes(post: :topic)
         .references(:topic)

--- a/lib/discourse_akismet/post_voting_comments_bouncer.rb
+++ b/lib/discourse_akismet/post_voting_comments_bouncer.rb
@@ -100,7 +100,6 @@ module DiscourseAkismet
 
     def args_for(comment, action)
       args = AntiSpamService.args_manager.new(comment, @@munger)
-
       action == "check" ? args.for_check : args.for_feedback
     end
 
@@ -125,6 +124,7 @@ module DiscourseAkismet
         ReviewableAkismetPostVotingComment.needs_review!(
           created_by: spam_reporter,
           target: comment,
+          target_created_by: spam_reporter,
           topic: comment.post.topic,
           reviewable_by_moderator: true,
           payload: {
@@ -141,6 +141,7 @@ module DiscourseAkismet
         ReviewableAkismetPostVotingComment.needs_review!(
           created_by: spam_reporter,
           target: comment,
+          target_created_by: spam_reporter,
           topic: comment.post.topic,
           reviewable_by_moderator: true,
           payload: {

--- a/lib/discourse_akismet/post_voting_comments_bouncer.rb
+++ b/lib/discourse_akismet/post_voting_comments_bouncer.rb
@@ -22,7 +22,7 @@ module DiscourseAkismet
           "LEFT OUTER JOIN reviewables ON reviewables.target_id = post_voting_comment_custom_fields.post_voting_comment_id",
         )
         .where("post_voting_comment_custom_fields.name = ?", AKISMET_STATE)
-        .where("post_voting_comment_custom_fields.value = ?", "pending")
+        .where("post_voting_comment_custom_fields.value = ?", DiscourseAkismet::Bouncer::PENDING_STATE)
         .where("reviewables.id IS NULL")
         .includes(post: :topic)
         .references(:topic)

--- a/lib/discourse_akismet/post_voting_comments_bouncer.rb
+++ b/lib/discourse_akismet/post_voting_comments_bouncer.rb
@@ -152,14 +152,6 @@ module DiscourseAkismet
       end
     end
 
-    # def notify_poster(comment)
-    #   SystemMessage.new(comment.user).create(
-    #     "akismet_spam",
-    #     topic_title: comment.post.topic.title,
-    #     comment_link: comment.full_url,
-    #   )
-    # end
-
     def comment_content(comment)
       return comment.raw unless comment.is_first_comment?
 

--- a/lib/discourse_akismet/post_voting_comments_bouncer.rb
+++ b/lib/discourse_akismet/post_voting_comments_bouncer.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+module DiscourseAkismet
+  class PostVotingCommentsBouncer < Bouncer
+    CUSTOM_FIELDS = %w[
+      AKISMET_STATE
+      AKISMET_IP_ADDRESS
+      AKISMET_USER_AGENT
+      AKISMET_REFERRER
+      NETEASE_TASK_ID
+    ]
+
+    @@munger = nil
+
+    #check this SQL query
+    def self.to_check
+      PostVotingComment
+        .joins(
+          "INNER JOIN post_voting_comment_custom_fields ON post_voting_comments.id = post_voting_comment_custom_fields.post_voting_comment_id",
+        )
+        .joins(
+          "LEFT OUTER JOIN reviewables ON reviewables.target_id = post_voting_comment_custom_fields.post_voting_comment_id",
+        )
+        .where("post_voting_comment_custom_fields.name = ?", AKISMET_STATE)
+        .where("post_voting_comment_custom_fields.value = ?", "pending")
+        .where("reviewables.id IS NULL")
+        .includes(post: :topic)
+        .references(:topic)
+    end
+
+    def suspect?(comment)
+      if comment.blank? || comment.post.blank? || comment.post.topic.blank? ||
+           (!SiteSetting.akismet_enabled?)
+        return false
+      end
+
+      # We don't run akismet on private messages
+      return false if comment.post.topic.private_message?
+
+      stripped = comment.raw.strip
+
+      # We only check posts over 20 chars
+      return false if stripped.size < 20
+
+      # Always check the first post of a TL1 user
+      if SiteSetting.review_tl1_users_first_post_voting_comment? &&
+           comment.user.trust_level == TrustLevel[1] && comment.user.post_count == 0
+        return true
+      end
+
+      # We only check certain trust levels
+      if comment.user.has_trust_level?(TrustLevel[SiteSetting.skip_akismet_trust_level.to_i])
+        return false
+      end
+
+      # If a user is locked, we don't want to check them forever
+      return false if comment.user.post_count > SiteSetting.skip_akismet_posts.to_i
+
+      # If the entire post is a URI we skip it. This might seem counter intuitive but
+      # Discourse already has settings for max links and images for new users. If they
+      # pass it means the administrator specifically allowed them.
+      uri =
+        begin
+          URI(stripped)
+        rescue StandardError
+          nil
+        end
+      return false if uri
+
+      # Otherwise check the post!
+      true
+    end
+
+    def store_additional_information(comment, opts = {})
+      values ||= {}
+      return if comment.blank? || AntiSpamService.api_secret_blank?
+
+      # Optional parameters to set
+      values["AKISMET_IP_ADDRESS"] = opts[:ip_address] if opts[:ip_address].present?
+      values["AKISMET_USER_AGENT"] = opts[:user_agent] if opts[:user_agent].present?
+      values["AKISMET_REFERRER"] = opts[:referrer] if opts[:referrer].present?
+
+      comment.upsert_custom_fields(values)
+    end
+
+    def clean_old_akismet_custom_fields
+      PostVotingCommentCustomField
+        .where(name: CUSTOM_FIELDS)
+        .where("created_at <= ?", 2.months.ago)
+        .delete_all
+    end
+
+    def self.munge_args(&block)
+      @@munger = block
+    end
+
+    def self.reset_munge
+      @@munger = nil
+    end
+
+    def args_for(comment, action)
+      args = AntiSpamService.args_manager.new(comment, @@munger)
+
+      action == "check" ? args.for_check : args.for_feedback
+    end
+
+    private
+
+    def enqueue_job(comment)
+      Jobs.enqueue(:check_akismet_post_voting_comment, comment_id: comment.id)
+    end
+
+    def before_check(comment)
+      return true unless comment.post.nil?
+      false
+    end
+
+    def mark_as_spam(comment)
+      comment.trash!
+
+      # Send a message to the user explaining that it happened
+      # notify_poster(comment) if SiteSetting.akismet_notify_user?
+
+      reviewable =
+        ReviewableAkismetPostVotingComment.needs_review!(
+          created_by: spam_reporter,
+          target: comment,
+          topic: comment.post.topic,
+          reviewable_by_moderator: true,
+          payload: {
+            comment_cooked: comment.cooked,
+          },
+        )
+
+      add_score(reviewable, "akismet_spam_comment")
+      move_to_state(comment, "confirmed_spam")
+    end
+
+    def mark_as_errored(comment, reason)
+      super do
+        ReviewableAkismetPostVotingComment.needs_review!(
+          created_by: spam_reporter,
+          target: comment,
+          topic: comment.post.topic,
+          reviewable_by_moderator: true,
+          payload: {
+            comment_cooked: comment.cooked,
+            external_error: reason,
+          },
+        )
+      end
+    end
+
+    # def notify_poster(comment)
+    #   SystemMessage.new(comment.user).create(
+    #     "akismet_spam",
+    #     topic_title: comment.post.topic.title,
+    #     comment_link: comment.full_url,
+    #   )
+    # end
+
+    def comment_content(comment)
+      return comment.raw unless comment.is_first_comment?
+
+      topic = comment.post.topic || Topic.with_deleted.find_by(id: comment.post.topic_id)
+      "#{topic && topic.title}\n\n#{comment.raw}"
+    end
+  end
+end

--- a/lib/discourse_akismet/posts_bouncer.rb
+++ b/lib/discourse_akismet/posts_bouncer.rb
@@ -18,7 +18,7 @@ module DiscourseAkismet
         .joins("INNER JOIN post_custom_fields ON posts.id = post_custom_fields.post_id")
         .joins("LEFT OUTER JOIN reviewables ON reviewables.target_id = post_custom_fields.post_id")
         .where("post_custom_fields.name = ?", AKISMET_STATE)
-        .where("post_custom_fields.value = ?", "pending")
+        .where("post_custom_fields.value = ?", DiscourseAkismet::Bouncer::PENDING_STATE)
         .where("reviewables.id IS NULL")
         .includes(:topic)
         .references(:topic)

--- a/lib/netease.rb
+++ b/lib/netease.rb
@@ -57,7 +57,7 @@ class Netease
     end
 
     def target_name
-      @target.class.to_s.split(/(?=[A-Z])/).join("_").downcase
+      @target.class.to_s.underscore
     end
 
     def post_content

--- a/lib/netease.rb
+++ b/lib/netease.rb
@@ -38,7 +38,7 @@ class Netease
     def for_post_voting_comment_check
       args = {
         dataId: "post-voting-comment-#{@target.id}",
-        content: post_voting_comment_content&.strip[0..MAXIMUM_CONTENT_LENGTH],
+        content: post_voting_comment_content&.strip&.[](0..MAXIMUM_CONTENT_LENGTH),
       }
 
       @munger.call(args) if @munger

--- a/lib/netease.rb
+++ b/lib/netease.rb
@@ -35,6 +35,17 @@ class Netease
       args
     end
 
+    def for_post_voting_comment_check
+      args = {
+        dataId: "post-voting-comment-#{@target.id}",
+        content: post_voting_comment_content&.strip[0..MAXIMUM_CONTENT_LENGTH],
+      }
+
+      @munger.call(args) if @munger
+
+      args
+    end
+
     def for_user_check
       bio = @target.user_profile&.bio_raw
 
@@ -46,7 +57,7 @@ class Netease
     end
 
     def target_name
-      @target.class.to_s.downcase
+      @target.class.to_s.split(/(?=[A-Z])/).join("_").downcase
     end
 
     def post_content
@@ -55,6 +66,13 @@ class Netease
 
       topic = @target.topic || Topic.with_deleted.find_by(id: @target.topic_id)
       "#{topic && topic.title}\n\n#{@target.raw}"
+    end
+
+    def post_voting_comment_content
+      return if !@target.is_a?(PostVotingComment)
+
+      post = @target.post || Post.with_deleted.find_by(id: @target.post_id)
+      "#{post && post.raw}\n\n#{@target.raw}"
     end
   end
 

--- a/lib/tasks/akismet.rake
+++ b/lib/tasks/akismet.rake
@@ -51,7 +51,7 @@ task "akismet:scan_old" => :environment do
     next if post.blank?
 
     DistributedMutex.synchronize("akismet_post_#{post.id}") do
-      bouncer.move_to_state(post, "pending")
+      bouncer.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
       bouncer.perform_check(client, post)
     end
 

--- a/models/reviewable_akismet_post_voting_comment.rb
+++ b/models/reviewable_akismet_post_voting_comment.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require_dependency "reviewable"
+
+class ReviewableAkismetPostVotingComment < Reviewable
+  def self.action_aliases
+    { confirm_suspend: :confirm_spam }
+  end
+
+  def build_actions(actions, guardian, _args)
+    return [] unless pending?
+
+    agree =
+      actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
+
+    build_action(actions, :confirm_spam, icon: "check", bundle: agree, has_description: true)
+
+    if guardian.can_suspend?(target_created_by)
+      build_action(
+        actions,
+        :confirm_suspend,
+        icon: "ban",
+        bundle: agree,
+        client_action: "suspend",
+        has_description: true,
+      )
+    end
+
+    if guardian.can_delete_user?(target_created_by)
+      # TODO: Remove after the 2.8 release
+      if respond_to?(:delete_user_actions)
+        delete_user_actions(actions)
+      else
+        build_action(actions, :confirm_delete, icon: "trash-alt", bundle: agree, confirm: true)
+      end
+    end
+
+    build_action(actions, :not_spam, icon: "thumbs-down")
+    build_action(actions, :ignore, icon: "external-link-alt")
+  end
+
+  def comment
+    @comment ||= (target || PostVotingComment.with_deleted.find_by(id: target_id))
+  end
+
+  # Reviewable#perform should be used instead of these action methods.
+  # These are only part of the public API because #perform needs them to be public.
+
+  def perform_confirm_spam(performed_by, _args)
+    bouncer.submit_feedback(comment, "spam")
+    log_confirmation(performed_by, "confirmed_spam")
+
+    # Double-check the original post is deleted
+    PostVotingCommentDestroyer.new(performed_by, comment).destroy unless comment.deleted_at?
+
+    successful_transition :approved, :agreed
+  end
+
+  def perform_not_spam(performed_by, _args)
+    bouncer.submit_feedback(comment, "ham")
+    log_confirmation(performed_by, "confirmed_ham")
+
+    if comment.deleted_at
+      PostVotingCommentDestroyer.new(performed_by, comment).recover
+      if SiteSetting.akismet_notify_user? && comment.reload.post.topic
+        SystemMessage.new(comment.user).create(
+          "akismet_not_spam",
+          topic_title: comment.post.topic.title,
+          post_link: comment.post.full_url,
+        )
+      end
+    end
+
+    successful_transition :rejected, :disagreed
+  end
+
+  def perform_ignore(performed_by, _args)
+    log_confirmation(performed_by, "ignored")
+
+    successful_transition :ignored, :ignored
+  end
+
+  def perform_delete_user(performed_by, args)
+    if Guardian.new(performed_by).can_delete_user?(target_created_by)
+      bouncer.submit_feedback(comment, "spam")
+      log_confirmation(performed_by, "confirmed_spam_deleted")
+
+      PostVotingCommentDestroyer.new(performed_by, comment).destroy unless comment.deleted_at?
+
+      opts = user_deletion_opts(performed_by, args)
+      UserDestroyer.new(performed_by).destroy(target_created_by, comment)
+    end
+
+    successful_transition :deleted, :agreed
+  end
+
+  def perform_delete_user_block(performed_by, args)
+    perform_delete_user(performed_by, args.merge(block_email: true, block_ip: true))
+  end
+  
+  alias perform_confirm_delete perform_delete_user_block
+  # TODO: Remove after the 2.8 release
+
+  private
+
+  def bouncer
+    DiscourseAkismet::PostsBouncer.new
+  end
+
+  def successful_transition(to_state, update_flag_status)
+    create_result(:success, to_state) do |result|
+      result.update_flag_stats = { status: update_flag_status, user_ids: [created_by_id] }
+    end
+  end
+
+  def build_action(
+    actions,
+    id,
+    icon:,
+    bundle: nil,
+    confirm: false,
+    button_class: nil,
+    client_action: nil,
+    has_description: true
+  )
+    actions.add(id, bundle: bundle) do |action|
+      action.icon = icon
+      action.label = "js.akismet.#{id}"
+      action.description = "js.akismet.#{id}_description" if has_description
+      action.confirm_message = "js.akismet.reviewable_delete_prompt" if confirm
+      action.client_action = client_action
+      action.button_class = button_class
+    end
+  end
+
+  def user_deletion_opts(performed_by, args)
+    {
+      context: I18n.t("akismet.delete_reason", performed_by: performed_by.username),
+      delete_posts: true,
+      block_urls: true,
+      delete_as_spammer: true,
+      block_email: !!args[:block_email],
+      block_ip: !!args[:block_ip],
+    }
+  end
+
+  def log_confirmation(performed_by, custom_type)
+    StaffActionLogger.new(performed_by).log_custom(
+      custom_type,
+      comment_id: comment.id,
+      post_id: comment.post.id,
+      topic_id: comment.post.topic_id,
+    )
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -40,6 +40,7 @@ after_initialize do
 
   register_reviewable_type ReviewableAkismetPost
   register_reviewable_type ReviewableAkismetUser
+  register_reviewable_type ReviewableAkismetPostVotingComment
 
   # TODO(roman): Remove else branch after 3.0 release.
   if respond_to?(:register_user_destroyer_on_content_deletion_callback)

--- a/plugin.rb
+++ b/plugin.rb
@@ -145,7 +145,10 @@ after_initialize do
   on(:post_recovered) do |post, _, _|
     # Ensure that posts that were deleted and thus skipped are eventually
     # checked.
-    next if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] != DiscourseAkismet::Bouncer::SKIPPED_STATE
+    if post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE] !=
+         DiscourseAkismet::Bouncer::SKIPPED_STATE
+      next
+    end
 
     bouncer = DiscourseAkismet::PostsBouncer.new
     check_post(bouncer, post) if bouncer.should_check?(post)

--- a/serializers/reviewable_akismet_post_voting_comment_serializer.rb
+++ b/serializers/reviewable_akismet_post_voting_comment_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_dependency "reviewable_serializer"
+
+class ReviewableAkismetPostVotingCommentSerializer < ReviewableSerializer
+  payload_attributes :comment_cooked, :post_id, :external_error
+end

--- a/spec/fabricators/reviewable_akismet_post_fabricator.rb
+++ b/spec/fabricators/reviewable_akismet_post_fabricator.rb
@@ -9,6 +9,15 @@ Fabricator(:reviewable_akismet_post) do
   target { Fabricate(:post) }
 end
 
+Fabricator(:reviewable_akismet_post_voting_comment) do
+  reviewable_by_moderator true
+  type "ReviewableAkismetPostVotingComment"
+  created_by { Discourse.system_user }
+  topic
+  target_type "PostVotingComment"
+  target { Fabricate(:post_voting_comment) }
+end
+
 Fabricator(:reviewable_akismet_user) do
   reviewable_by_moderator true
   type "ReviewableAkismetUser"

--- a/spec/fabricators/reviewable_akismet_post_fabricator.rb
+++ b/spec/fabricators/reviewable_akismet_post_fabricator.rb
@@ -9,13 +9,17 @@ Fabricator(:reviewable_akismet_post) do
   target { Fabricate(:post) }
 end
 
-Fabricator(:reviewable_akismet_post_voting_comment) do
+Fabricator(
+  :reviewable_akismet_post_voting_comment,
+  class_name: "ReviewableAkismetPostVotingComment",
+) do
   reviewable_by_moderator true
   type "ReviewableAkismetPostVotingComment"
-  created_by { Discourse.system_user }
-  topic
-  target_type "PostVotingComment"
+  created_by { Fabricate(:user) }
   target { Fabricate(:post_voting_comment) }
+  reviewable_scores do |p|
+    [Fabricate.build(:reviewable_score, reviewable_id: p[:id], user: p[:created_by])]
+  end
 end
 
 Fabricator(:reviewable_akismet_user) do

--- a/spec/jobs/regular/check_akismet_post_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Jobs::CheckAkismetPost do
       before do
         SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
         SiteSetting.akismet_api_key = "fake_key"
-        DiscourseAkismet::PostsBouncer.new.move_to_state(post, "pending")
+        DiscourseAkismet::PostsBouncer.new.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
       end
 
       context "when client returns spam" do
@@ -74,7 +74,7 @@ RSpec.describe Jobs::CheckAkismetPost do
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"
-        DiscourseAkismet::PostsBouncer.new.move_to_state(post, "pending")
+        DiscourseAkismet::PostsBouncer.new.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
       end
 
       context "when client returns spam" do

--- a/spec/jobs/regular/check_akismet_post_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe Jobs::CheckAkismetPost do
       before do
         SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
         SiteSetting.akismet_api_key = "fake_key"
-        DiscourseAkismet::PostsBouncer.new.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
+        DiscourseAkismet::PostsBouncer.new.move_to_state(
+          post,
+          DiscourseAkismet::Bouncer::PENDING_STATE,
+        )
       end
 
       context "when client returns spam" do
@@ -74,7 +77,10 @@ RSpec.describe Jobs::CheckAkismetPost do
         SiteSetting.netease_secret_id = "netease_id"
         SiteSetting.netease_secret_key = "netease_key"
         SiteSetting.netease_business_id = "business_id"
-        DiscourseAkismet::PostsBouncer.new.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
+        DiscourseAkismet::PostsBouncer.new.move_to_state(
+          post,
+          DiscourseAkismet::Bouncer::PENDING_STATE,
+        )
       end
 
       context "when client returns spam" do

--- a/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Jobs::CheckAkismetPostVotingComment do
 
   before { SiteSetting.akismet_enabled = true }
   describe "#execute" do
-  subject(:check_akismet_post_voting_comment) { described_class.new }
+    subject(:check_akismet_post_voting_comment) { described_class.new }
 
     it "does not create a reviewable when a reviewable flagged post already exists for that target" do
       ReviewablePostVotingComment.needs_review!(

--- a/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Jobs::CheckAkismetPostVotingComment do
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:post_voting_comment) { Fabricate(:post_voting_comment, post: post) }
+
+  before { SiteSetting.akismet_enabled = true }
+  describe "#execute" do
+    # it "does not create a reviewable when a reviewable queued post voting comment already exists for that target" do
+    #   ReviewableQueuedPost.needs_review!(target: post_voting_comment, created_by: Discourse.system_user)
+
+    #   subject.execute(comment_id: post_voting_comment.id)
+
+    #   expect(ReviewableAkismetPostVotingComment.count).to be_zero
+    # end
+    it "does not create a reviewable when a reviewable flagged post already exists for that target" do
+      ReviewablePostVotingComment.needs_review!(
+        target: post_voting_comment,
+        created_by: Discourse.system_user,
+      )
+
+      subject.execute(comment_id: post_voting_comment.id)
+
+      expect(ReviewableAkismetPostVotingComment.count).to be_zero
+    end
+
+    shared_examples "confirmed ham post voting comments" do
+      it "does not create a reviewable for non-spam post" do
+        subject.execute(comment_id: post_voting_comment.id)
+
+        expect(ReviewableAkismetPostVotingComment.count).to be_zero
+        expect(
+          post_voting_comment.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE],
+        ).to eq("confirmed_ham")
+      end
+    end
+
+    shared_examples "confirmed spam post voting comments" do
+      it "creates a reviewable for spam post" do
+        subject.execute(comment_id: post_voting_comment.id)
+
+        expect(ReviewableAkismetPostVotingComment.count).to eq(1)
+        expect(
+          post_voting_comment.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE],
+        ).to eq("confirmed_spam")
+      end
+    end
+
+    context "with akismet" do
+      before do
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
+        SiteSetting.akismet_api_key = "fake_key"
+        DiscourseAkismet::PostVotingCommentsBouncer.new.move_to_state(
+          post_voting_comment,
+          "pending",
+        )
+      end
+
+      context "when client returns spam" do
+        before { Akismet::Client.any_instance.stubs(:comment_check).returns("spam") }
+
+        include_examples "confirmed spam post voting comments"
+      end
+
+      context "when client returns ham" do
+        before { Akismet::Client.any_instance.stubs(:comment_check).returns("ham") }
+
+        include_examples "confirmed ham post voting comments"
+      end
+    end
+
+    context "with netease" do
+      before do
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
+        DiscourseAkismet::PostVotingCommentsBouncer.new.move_to_state(
+          post_voting_comment,
+          "pending",
+        )
+      end
+
+      context "when client returns spam" do
+        before { Netease::Client.any_instance.stubs(:comment_check).returns("spam") }
+
+        include_examples "confirmed spam post voting comments"
+      end
+
+      context "when client returns ham" do
+        before { Netease::Client.any_instance.stubs(:comment_check).returns("ham") }
+
+        include_examples "confirmed ham post voting comments"
+      end
+    end
+  end
+end

--- a/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
@@ -9,27 +9,22 @@ RSpec.describe Jobs::CheckAkismetPostVotingComment do
 
   before { SiteSetting.akismet_enabled = true }
   describe "#execute" do
-    # it "does not create a reviewable when a reviewable queued post voting comment already exists for that target" do
-    #   ReviewableQueuedPost.needs_review!(target: post_voting_comment, created_by: Discourse.system_user)
+  subject(:check_akismet_post_voting_comment) { described_class.new }
 
-    #   subject.execute(comment_id: post_voting_comment.id)
-
-    #   expect(ReviewableAkismetPostVotingComment.count).to be_zero
-    # end
     it "does not create a reviewable when a reviewable flagged post already exists for that target" do
       ReviewablePostVotingComment.needs_review!(
         target: post_voting_comment,
         created_by: Discourse.system_user,
       )
 
-      subject.execute(comment_id: post_voting_comment.id)
+      check_akismet_post_voting_comment.execute(comment_id: post_voting_comment.id)
 
       expect(ReviewableAkismetPostVotingComment.count).to be_zero
     end
 
     shared_examples "confirmed ham post voting comments" do
       it "does not create a reviewable for non-spam post" do
-        subject.execute(comment_id: post_voting_comment.id)
+        check_akismet_post_voting_comment.execute(comment_id: post_voting_comment.id)
 
         expect(ReviewableAkismetPostVotingComment.count).to be_zero
         expect(
@@ -40,7 +35,7 @@ RSpec.describe Jobs::CheckAkismetPostVotingComment do
 
     shared_examples "confirmed spam post voting comments" do
       it "creates a reviewable for spam post" do
-        subject.execute(comment_id: post_voting_comment.id)
+        check_akismet_post_voting_comment.execute(comment_id: post_voting_comment.id)
 
         expect(ReviewableAkismetPostVotingComment.count).to eq(1)
         expect(

--- a/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
+++ b/spec/jobs/regular/check_akismet_post_voting_comment_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Jobs::CheckAkismetPostVotingComment do
         SiteSetting.akismet_api_key = "fake_key"
         DiscourseAkismet::PostVotingCommentsBouncer.new.move_to_state(
           post_voting_comment,
-          "pending",
+          DiscourseAkismet::Bouncer::PENDING_STATE,
         )
       end
 
@@ -75,7 +75,7 @@ RSpec.describe Jobs::CheckAkismetPostVotingComment do
         SiteSetting.netease_business_id = "business_id"
         DiscourseAkismet::PostVotingCommentsBouncer.new.move_to_state(
           post_voting_comment,
-          "pending",
+          DiscourseAkismet::Bouncer::PENDING_STATE,
         )
       end
 

--- a/spec/jobs/scheduled/check_for_spam_users_spec.rb
+++ b/spec/jobs/scheduled/check_for_spam_users_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Jobs::CheckForSpamUsers do
           UserAuthTokenLog.create!(client_ip: "127.0.0.1", action: "an_action", user: u)
         end
 
-      DiscourseAkismet::UsersBouncer.new.move_to_state(user, "pending")
+      DiscourseAkismet::UsersBouncer.new.move_to_state(user, DiscourseAkismet::Bouncer::PENDING_STATE)
 
       subject.execute({})
 

--- a/spec/jobs/scheduled/check_for_spam_users_spec.rb
+++ b/spec/jobs/scheduled/check_for_spam_users_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe Jobs::CheckForSpamUsers do
           UserAuthTokenLog.create!(client_ip: "127.0.0.1", action: "an_action", user: u)
         end
 
-      DiscourseAkismet::UsersBouncer.new.move_to_state(user, DiscourseAkismet::Bouncer::PENDING_STATE)
+      DiscourseAkismet::UsersBouncer.new.move_to_state(
+        user,
+        DiscourseAkismet::Bouncer::PENDING_STATE,
+      )
 
       subject.execute({})
 

--- a/spec/lib/post_voting_comments_bouncer_spec.rb
+++ b/spec/lib/post_voting_comments_bouncer_spec.rb
@@ -144,7 +144,7 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
     end
 
     describe "#clean_old_akismet_custom_fields" do
-      before { bouncer.move_to_state(comment, "skipped") }
+      before { bouncer.move_to_state(comment, DiscourseAkismet::Bouncer::SKIPPED_STATE) }
 
       it "keeps recent Akismet custom fields" do
         comment.upsert_custom_fields("NETEASE_TASK_ID" => "task_id_123")
@@ -172,7 +172,7 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
   describe "#check_post_voting_comment" do
     let(:client) { DiscourseAkismet::AntiSpamService.client }
 
-    before { bouncer.move_to_state(comment, "pending") }
+    before { bouncer.move_to_state(comment, DiscourseAkismet::Bouncer::PENDING_STATE) }
 
     shared_examples "successful post voting comment checks" do
       it "creates a new ReviewableAkismetPostVotingComment when spam is confirmed by Akismet" do
@@ -186,7 +186,6 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
         expect(
           reviewable_akismet_post_voting_comment.payload["comment_cooked"],
         ).to eq comment.cooked
-
       end
 
       it "creates a new score for the new reviewable" do
@@ -251,7 +250,7 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
       end
 
       it "creates a new ReviewableAkismetPostVotingComment when an API error is returned" do
-        bouncer.move_to_state(comment, "pending")
+        bouncer.move_to_state(comment, DiscourseAkismet::Bouncer::PENDING_STATE)
         bouncer.perform_check(client, comment)
         reviewable_akismet_post_voting_comment = ReviewableAkismetPostVotingComment.last
 
@@ -284,7 +283,7 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
       end
 
       it "creates a new ReviewableAkismetPostVotingComment when an API error is returned" do
-        bouncer.move_to_state(comment, "pending")
+        bouncer.move_to_state(comment, DiscourseAkismet::Bouncer::PENDING_STATE)
         bouncer.perform_check(client, comment)
         reviewable_akismet_post_voting_comment = ReviewableAkismetPostVotingComment.last
 
@@ -306,7 +305,7 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
 
   describe "#to_check" do
     it "retrieves post voting comments waiting to be reviewed by Akismet" do
-      bouncer.move_to_state(comment, "pending")
+      bouncer.move_to_state(comment, DiscourseAkismet::Bouncer::PENDING_STATE)
 
       post_voting_comments_to_check = described_class.to_check
 
@@ -314,7 +313,7 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
     end
 
     it "does not retrieve post voting comments that already had another reviewable flagged post voting comment" do
-      bouncer.move_to_state(comment, "pending")
+      bouncer.move_to_state(comment, DiscourseAkismet::Bouncer::PENDING_STATE)
       ReviewablePostVotingComment.needs_review!(target: comment, created_by: Discourse.system_user)
       expect(described_class.to_check).to be_empty
     end

--- a/spec/lib/post_voting_comments_bouncer_spec.rb
+++ b/spec/lib/post_voting_comments_bouncer_spec.rb
@@ -1,0 +1,390 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../fabricators/reviewable_akismet_post_fabricator.rb"
+
+describe DiscourseAkismet::PostVotingCommentsBouncer do
+  before do
+    SiteSetting.akismet_api_key = "akismetkey"
+    SiteSetting.akismet_enabled = true
+
+    @referrer = "https://discourse.org"
+    @ip_address = "1.2.3.4"
+    @user_agent = "Discourse Agent"
+
+    subject.store_additional_information(
+      comment,
+      { ip_address: @ip_address, user_agent: @user_agent, referrer: @referrer },
+    )
+  end
+
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:comment) { Fabricate(:post_voting_comment, post: post) }
+
+  describe "#args_for" do
+    context "with akismet" do
+      before { SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET }
+
+      it "returns args for a post voting comment" do
+        result = subject.args_for(comment, "check")
+        expect(result[:content_type]).to eq("post-voting-comment")
+        expect(result[:permalink]).to be_present
+        expect(result[:comment_content]).to be_present
+        expect(result[:user_ip]).to eq(@ip_address)
+        expect(result[:referrer]).to eq(@referrer)
+        expect(result[:user_agent]).to eq(@user_agent)
+        expect(result[:comment_author]).to eq(comment.user.username)
+        expect(result[:comment_author_email]).to eq(comment.user.email)
+        expect(result[:blog]).to eq(Discourse.base_url)
+      end
+
+      it "will omit email if the site setting is enabled" do
+        SiteSetting.akismet_transmit_email = false
+        result = subject.args_for(comment, "check")
+        expect(result[:comment_author_email]).to be_blank
+      end
+
+      it "works with deleted posts voting comments and posts" do
+        comment.trash!
+        deleted_comment = PostVotingComment.unscoped.find(comment.id)
+        result = subject.args_for(deleted_comment, "check")
+
+        expect(result[:comment_content]).to include(comment.post.raw)
+      end
+
+      context "with custom munge" do
+        after { described_class.reset_munge }
+
+        before do
+          described_class.munge_args do |args|
+            args[:comment_author] = "CUSTOM: #{args[:comment_author]}"
+            args.delete(:user_agent)
+          end
+        end
+
+        it "will munge the args before returning them" do
+          result = subject.args_for(comment, "check")
+          expect(result[:user_agent]).to be_blank
+          expect(result[:comment_author]).to eq("CUSTOM: #{comment.user.username}")
+
+          described_class.reset_munge
+          result = subject.args_for(comment, "check")
+          expect(result[:user_agent]).to eq("Discourse Agent")
+          expect(result[:comment_author]).to eq(comment.user.username)
+        end
+      end
+    end
+
+    context "with netease" do
+      before do
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
+      end
+
+      it "returns args for a post voting comment" do
+        result = subject.args_for(comment, "check")
+        expect(result).to include(
+          dataId: "post-voting-comment-#{comment.id}",
+          content: "#{comment.post.raw}\n\nHello world",
+        )
+      end
+
+      it "omits email if the site setting is enabled" do
+        SiteSetting.akismet_transmit_email = false
+        result = subject.args_for(comment, "check")
+
+        expect(result.values).not_to include(comment.user.email)
+      end
+
+      it "returns args for deleted posts voting comments" do
+        comment.trash!
+        deleted_comment = PostVotingComment.unscoped.find(comment.id)
+
+        result = subject.args_for(deleted_comment, "check")
+
+        expect(result[:content]).to include(comment.post.raw)
+      end
+
+      context "with custom munge" do
+        after { described_class.reset_munge }
+
+        before do
+          described_class.munge_args do |args|
+            args[:dataId] = "#{Discourse.current_hostname}-#{args[:dataId]}"
+          end
+        end
+
+        it "munges the args before returning them" do
+          result = subject.args_for(comment, "check")
+          expect(result[:dataId]).to eq(
+            "#{Discourse.current_hostname}-post-voting-comment-#{comment.id}",
+          )
+
+          described_class.reset_munge
+          result = subject.args_for(comment, "check")
+          expect(result[:dataId]).to eq("post-voting-comment-#{comment.id}")
+        end
+      end
+    end
+  end
+
+  describe "custom fields" do
+    it "custom fields can be attached and IPs anonymized" do
+      expect(comment.custom_fields["AKISMET_IP_ADDRESS"]).to eq(@ip_address)
+      expect(comment.custom_fields["AKISMET_REFERRER"]).to eq(@referrer)
+      expect(comment.custom_fields["AKISMET_USER_AGENT"]).to eq(@user_agent)
+      UserAnonymizer.new(comment.user, nil, anonymize_ip: "0.0.0.0").make_anonymous
+      comment.reload
+      expect(comment.custom_fields["AKISMET_IP_ADDRESS"]).to eq("0.0.0.0")
+    end
+
+    describe "#clean_old_akismet_custom_fields" do
+      before { subject.move_to_state(comment, "skipped") }
+
+      it "keeps recent Akismet custom fields" do
+        comment.upsert_custom_fields("NETEASE_TASK_ID" => "task_id_123")
+        subject.clean_old_akismet_custom_fields
+
+        comment.reload
+
+        expect(comment.custom_fields.keys).to contain_exactly(*described_class::CUSTOM_FIELDS)
+      end
+
+      it "removes old Akismet custom fields" do
+        PostVotingCommentCustomField.where(
+          name: described_class::CUSTOM_FIELDS,
+          post_voting_comment: comment,
+        ).update_all(created_at: 3.months.ago)
+
+        subject.clean_old_akismet_custom_fields
+
+        comment.reload
+        expect(comment.custom_fields.keys).to be_empty
+      end
+    end
+  end
+
+  describe "#check_post_voting_comment" do
+    let(:client) { DiscourseAkismet::AntiSpamService.client }
+
+    before { subject.move_to_state(comment, "pending") }
+
+    shared_examples "successful post voting comment checks" do
+      it "creates a new ReviewableAkismetPostVotingComment when spam is confirmed by Akismet" do
+        subject.perform_check(client, comment)
+
+        reviewable_akismet_post_voting_comment = ReviewableAkismetPostVotingComment.last
+
+        expect(reviewable_akismet_post_voting_comment).to be_pending
+        expect(reviewable_akismet_post_voting_comment.comment).to eq comment
+        expect(reviewable_akismet_post_voting_comment.reviewable_by_moderator).to eq true
+        expect(
+          reviewable_akismet_post_voting_comment.payload["comment_cooked"],
+        ).to eq comment.cooked
+
+        # notifies user that post is hidden and includes post URL
+
+        # expect(PostVotingComment.unscoped.last.raw).to include(comment.full_url)
+        # expect(PostVotingComment.unscoped.last.raw).to include(comment.topic.title)
+      end
+
+      it "creates a new score for the new reviewable" do
+        subject.perform_check(client, comment)
+        reviewable_akismet_score = ReviewableScore.last
+
+        expect(reviewable_akismet_score.user).to eq Discourse.system_user
+        expect(reviewable_akismet_score.reviewable_score_type).to eq PostActionType.types[:spam]
+        expect(reviewable_akismet_score.take_action_bonus).to be_zero
+      end
+    end
+
+    context "with akismet success reponse" do
+      before do
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::AKISMET
+        stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
+          status: 200,
+          body: "true",
+        )
+      end
+
+      include_examples "successful post voting comment checks"
+    end
+
+    context "with neteaase success response" do
+      before do
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
+
+        stub_request(:post, "http://as.dun.163.com/v5/text/check").to_return(
+          status: 200,
+          body: {
+            code: 200,
+            msg: "ok",
+            result: {
+              antispam: {
+                taskId: "fx6sxdcd89fvbvg4967b4787d78a",
+                dataId: "dataId",
+                suggestion: 1,
+              },
+            },
+          }.to_json,
+        )
+      end
+
+      include_examples "successful post voting comment checks"
+    end
+
+    context "with akismet API error" do
+      before do
+        stub_request(:post, "https://akismetkey.rest.akismet.com/1.1/comment-check").to_return(
+          status: 200,
+          body: "false",
+          headers: {
+            "X-akismet-error" => "status",
+            "X-akismet-alert-code" => "123",
+            "X-akismet-alert-msg" => "An alert message",
+          },
+        )
+      end
+
+      it "creates a new ReviewableAkismetPostVotingComment when an API error is returned" do
+        subject.move_to_state(comment, "pending")
+        subject.perform_check(client, comment)
+        reviewable_akismet_post_voting_comment = ReviewableAkismetPostVotingComment.last
+
+        expect(reviewable_akismet_post_voting_comment).to be_pending
+        expect(reviewable_akismet_post_voting_comment.comment).to eq comment
+        expect(reviewable_akismet_post_voting_comment.reviewable_by_moderator).to eq true
+        expect(reviewable_akismet_post_voting_comment.payload["external_error"]["error"]).to eq(
+          "status",
+        )
+        expect(reviewable_akismet_post_voting_comment.payload["external_error"]["code"]).to eq(
+          "123",
+        )
+        expect(reviewable_akismet_post_voting_comment.payload["external_error"]["msg"]).to eq(
+          "An alert message",
+        )
+      end
+    end
+
+    context "with netease API error" do
+      before do
+        SiteSetting.anti_spam_service = DiscourseAkismet::AntiSpamService::NETEASE
+        SiteSetting.netease_secret_id = "netease_id"
+        SiteSetting.netease_secret_key = "netease_key"
+        SiteSetting.netease_business_id = "business_id"
+
+        stub_request(:post, "http://as.dun.163.com/v5/text/check").to_return(
+          status: 200,
+          body: { code: 400, msg: "Missing SecretId or businessId" }.to_json,
+        )
+      end
+
+      it "creates a new ReviewableAkismetPostVotingComment when an API error is returned" do
+        subject.move_to_state(comment, "pending")
+        subject.perform_check(client, comment)
+        reviewable_akismet_post_voting_comment = ReviewableAkismetPostVotingComment.last
+
+        expect(reviewable_akismet_post_voting_comment).to be_pending
+        expect(reviewable_akismet_post_voting_comment.comment).to eq comment
+        expect(reviewable_akismet_post_voting_comment.reviewable_by_moderator).to eq true
+        expect(reviewable_akismet_post_voting_comment.payload["external_error"]["error"]).to eq(
+          "Missing SecretId or businessId",
+        )
+        expect(reviewable_akismet_post_voting_comment.payload["external_error"]["code"]).to eq(
+          "400",
+        )
+        expect(reviewable_akismet_post_voting_comment.payload["external_error"]["msg"]).to eq(
+          "Missing SecretId or businessId",
+        )
+      end
+    end
+  end
+
+  describe "#to_check" do
+    it "retrieves post voting comments waiting to be reviewed by Akismet" do
+      subject.move_to_state(comment, "pending")
+
+      post_voting_comments_to_check = described_class.to_check
+
+      expect(post_voting_comments_to_check).to contain_exactly(comment)
+    end
+
+    it "does not retrieve post voting comments that already had another reviewable flagged post voting comment" do
+      subject.move_to_state(comment, "pending")
+      ReviewablePostVotingComment.needs_review!(target: comment, created_by: Discourse.system_user)
+      expect(described_class.to_check).to be_empty
+    end
+  end
+
+  describe "#should_check?" do
+    let(:user) { comment.user }
+
+    it { expect(subject.should_check?(nil)).to eq(false) }
+
+    before do
+      SiteSetting.skip_akismet_trust_level = TrustLevel[2]
+
+      user.user_stat # Create user stat object
+
+      post.raw = "More than 20 characters long"
+      comment.raw = "More than 500 characters long"
+      user.trust_level = TrustLevel[1]
+    end
+
+    it "returns true on the first post of a TL1 user" do
+      SiteSetting.skip_akismet_trust_level = TrustLevel[1]
+
+      expect(subject.should_check?(comment)).to eq(true)
+    end
+
+    it "returns false for a TL1 user's first post when the setting is disabled" do
+      SiteSetting.review_tl1_users_first_post_voting_comment = false
+      SiteSetting.skip_akismet_trust_level = TrustLevel[1]
+
+      expect(subject.should_check?(comment)).to eq(false)
+    end
+
+    it "returns false the topic was deleted" do
+      comment.post.topic.trash!
+      expect(subject.should_check?(comment.reload)).to eq(false)
+    end
+
+    it "returns false the post voting comment body is less than 20 chars long" do
+      comment.raw = "Less than 20 chars"
+
+      expect(subject.should_check?(comment)).to eq(false)
+    end
+
+    it "returns false when TL0+ users are skipped" do
+      user.user_stat.post_count = 2
+      SiteSetting.skip_akismet_trust_level = TrustLevel[0]
+
+      expect(subject.should_check?(comment)).to eq(false)
+    end
+
+    it "returns false when post voting comment content is just an URI" do
+      user.user_stat.post_count = 2
+      comment.raw = "https://testurl.test/test/akismet/96850311111131"
+
+      expect(subject.should_check?(comment)).to eq(false)
+    end
+
+    it "returns false when the plugin is disabled" do
+      SiteSetting.akismet_enabled = false
+
+      expect(subject.should_check?(comment)).to eq(false)
+    end
+
+    it "returns false when a reviewable already exists" do
+      Fabricate(:reviewable_akismet_post_voting_comment, target: comment)
+
+      expect(subject.should_check?(comment)).to eq(false)
+    end
+  end
+end

--- a/spec/lib/post_voting_comments_bouncer_spec.rb
+++ b/spec/lib/post_voting_comments_bouncer_spec.rb
@@ -187,10 +187,6 @@ describe DiscourseAkismet::PostVotingCommentsBouncer do
           reviewable_akismet_post_voting_comment.payload["comment_cooked"],
         ).to eq comment.cooked
 
-        # notifies user that post is hidden and includes post URL
-
-        # expect(PostVotingComment.unscoped.last.raw).to include(comment.full_url)
-        # expect(PostVotingComment.unscoped.last.raw).to include(comment.topic.title)
       end
 
       it "creates a new score for the new reviewable" do

--- a/spec/lib/posts_bouncer_spec.rb
+++ b/spec/lib/posts_bouncer_spec.rb
@@ -144,7 +144,7 @@ describe DiscourseAkismet::PostsBouncer do
     end
 
     describe "#clean_old_akismet_custom_fields" do
-      before { bouncer.move_to_state(post, "skipped") }
+      before { bouncer.move_to_state(post, DiscourseAkismet::Bouncer::SKIPPED_STATE) }
 
       it "keeps recent Akismet custom fields" do
         post.upsert_custom_fields("NETEASE_TASK_ID" => "task_id_123")
@@ -171,7 +171,7 @@ describe DiscourseAkismet::PostsBouncer do
   describe "#check_post" do
     let(:client) { DiscourseAkismet::AntiSpamService.client }
 
-    before { bouncer.move_to_state(post, "pending") }
+    before { bouncer.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE) }
 
     shared_examples "successful post checks" do
       it "creates a new ReviewableAkismetPost when spam is confirmed by Akismet" do
@@ -259,7 +259,7 @@ describe DiscourseAkismet::PostsBouncer do
       end
 
       it "creates a new ReviewableAkismetPost when an API error is returned" do
-        bouncer.move_to_state(post, "pending")
+        bouncer.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
         bouncer.perform_check(client, post)
         reviewable_akismet_post = ReviewableAkismetPost.last
 
@@ -286,7 +286,7 @@ describe DiscourseAkismet::PostsBouncer do
       end
 
       it "creates a new ReviewableAkismetPost when an API error is returned" do
-        bouncer.move_to_state(post, "pending")
+        bouncer.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
         bouncer.perform_check(client, post)
         reviewable_akismet_post = ReviewableAkismetPost.last
 
@@ -306,7 +306,7 @@ describe DiscourseAkismet::PostsBouncer do
 
   describe "#to_check" do
     it "retrieves posts waiting to be reviewed by Akismet" do
-      bouncer.move_to_state(post, "pending")
+      bouncer.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
 
       posts_to_check = described_class.to_check
 
@@ -314,14 +314,14 @@ describe DiscourseAkismet::PostsBouncer do
     end
 
     it "does not retrieve posts that already had another reviewable queued post" do
-      bouncer.move_to_state(post, "pending")
+      bouncer.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
       ReviewableQueuedPost.needs_review!(target: post, created_by: Discourse.system_user)
 
       expect(described_class.to_check).to be_empty
     end
 
     it "does not retrieve posts that already had another reviewable flagged post" do
-      bouncer.move_to_state(post, "pending")
+      bouncer.move_to_state(post, DiscourseAkismet::Bouncer::PENDING_STATE)
       ReviewableFlaggedPost.needs_review!(target: post, created_by: Discourse.system_user)
 
       expect(described_class.to_check).to be_empty

--- a/spec/lib/users_bouncer_spec.rb
+++ b/spec/lib/users_bouncer_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
     it "returns users in new state and ignore the rest" do
       user_to_check = Fabricate(:user, trust_level: 0)
       user_to_ignore = Fabricate(:user, trust_level: 0)
-      bouncer.move_to_state(user_to_check, "pending")
+      bouncer.move_to_state(user_to_check, DiscourseAkismet::Bouncer::PENDING_STATE)
       bouncer.move_to_state(user_to_ignore, "confirmed_ham")
 
       expect(described_class.to_check).to contain_exactly(user_to_check)
@@ -203,21 +203,21 @@ RSpec.describe DiscourseAkismet::UsersBouncer do
 
     it "only checks TL0 users" do
       user = Fabricate(:user, trust_level: 1)
-      bouncer.move_to_state(user, "pending")
+      bouncer.move_to_state(user, DiscourseAkismet::Bouncer::PENDING_STATE)
 
       expect(described_class.to_check).to be_empty
     end
 
     it "re-checks skipped users" do
       user = Fabricate(:user, trust_level: 0)
-      bouncer.move_to_state(user, "skipped")
+      bouncer.move_to_state(user, DiscourseAkismet::Bouncer::SKIPPED_STATE)
 
       expect(described_class.to_check).to contain_exactly(user)
     end
 
     it "does not check skipped users created more than 24 hours ago" do
       user = Fabricate(:user, trust_level: 0, created_at: 2.days.ago)
-      bouncer.move_to_state(user, "skipped")
+      bouncer.move_to_state(user, DiscourseAkismet::Bouncer::SKIPPED_STATE)
 
       expect(described_class.to_check).to be_empty
     end

--- a/spec/models/reviewable_akismet_post_voting_comment_spec.rb
+++ b/spec/models/reviewable_akismet_post_voting_comment_spec.rb
@@ -169,24 +169,6 @@ describe "ReviewableAkismetPost" do
           DiscourseEvent.off(:post_recovered, &blk)
         end
       end
-
-      # it "Sends a system message to the user" do
-      #   expect { reviewable.perform admin, action }.to change { Topic.private_messages.count }.by(1)
-
-      #   pm = Topic.private_messages.last
-      #   expect(pm.allowed_users).to contain_exactly(Discourse.system_user, post.user)
-      # end
-
-      # it "Does not send a system message to the user if topic is gone" do
-      #   first_post = Fabricate(:post_with_long_raw_content)
-      #   post = Fabricate(:post_with_long_raw_content, topic: first_post.topic)
-      #   comment.trash!(Discourse.system_user)
-      #   reviewable =
-      #     ReviewableAkismetPostVotingComment.needs_review!(target: post, created_by: Discourse.system_user)
-      #   PostDestroyer.new(Discourse.system_user, first_post).destroy
-
-      #   expect { reviewable.perform admin, action }.not_to change { Topic.private_messages.count }
-      # end
     end
 
     describe "#perform_ignore" do

--- a/spec/models/reviewable_akismet_post_voting_comment_spec.rb
+++ b/spec/models/reviewable_akismet_post_voting_comment_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "ReviewableAkismetPostVotingComment" do
+  let(:guardian) { Guardian.new }
+
+  before { SiteSetting.akismet_enabled = true }
+
+  describe "#build_actions" do
+    fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
+    fab!(:post) { Fabricate(:post, topic: topic) }
+    fab!(:comment) { Fabricate(:post_voting_comment, post: post) }
+    let!(:reviewable) do
+      ReviewableAkismetPostVotingComment.new(target: comment)
+    end
+
+    before { reviewable.created_new! }
+
+    it "Does not return available actions when the reviewable is no longer pending" do
+      available_actions =
+        (Reviewable.statuses.symbolize_keys.keys - [:pending]).reduce([]) do |actions, status|
+          reviewable.status = Reviewable.statuses[status]
+          an_action_id = :confirm_spam
+
+          actions.concat reviewable_actions(guardian).to_a
+        end
+
+      expect(available_actions).to be_empty
+    end
+
+    it "Adds the confirm spam action" do
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:confirm_spam)).to be true
+    end
+
+    it "Adds the not spam action" do
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:not_spam)).to be true
+    end
+
+    it "Adds the dismiss action" do
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:ignore)).to be true
+    end
+
+    it "Adds the delete and delete + block actions" do
+      admin = Fabricate(:admin)
+      guardian = Guardian.new(admin)
+
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:delete_user)).to be true
+      expect(actions.has?(:delete_user_block)).to be true
+    end
+
+    it "Excludes the confirm delete action when the user is not an staff member" do
+      actions = reviewable_actions(guardian)
+
+      expect(actions.has?(:confirm_delete)).to be false
+    end
+
+    def reviewable_actions(guardian)
+      actions = Reviewable::Actions.new(reviewable, guardian, {})
+      reviewable.build_actions(actions, guardian, {})
+
+      actions
+    end
+  end
+
+  describe "Performing actions on reviewable" do
+    fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
+    let(:admin) { Fabricate(:admin) }
+    fab!(:post) { Fabricate(:post_with_long_raw_content, topic: topic) }
+    fab!(:comment) { Fabricate(:post_voting_comment, post: post) }
+    let(:reviewable) do
+      ReviewableAkismetPostVotingComment.needs_review!(
+        target: comment,
+        created_by: admin,
+      )
+    end
+
+    before { PostDestroyer.new(admin, post).destroy }
+
+    shared_examples "a staff action logger" do
+      it "Creates a UserHistory that reflects the action taken" do
+        reviewable.perform admin, action
+
+        admin_last_action = UserHistory.find_by(post: post)
+
+        assert_history_reflects_action(admin_last_action, admin, post, action_name)
+      end
+
+      def assert_history_reflects_action(action, admin, post, action_name)
+        expect(action.custom_type).to eq action_name
+        expect(action.post_id).to eq post.id
+        expect(action.topic_id).to eq post.topic_id
+      end
+
+      it "Returns necessary information to update reviewable creator user stats" do
+        result = reviewable.perform admin, action
+
+        update_flag_stats = result.update_flag_stats
+
+        expect(update_flag_stats[:status]).to eq flag_stat_status
+        expect(update_flag_stats[:user_ids]).to match_array [reviewable.created_by_id]
+      end
+    end
+
+    shared_examples "an Akismet feedback submission" do
+      it "queues a job to submit feedback" do
+        expect { reviewable.perform admin, action }.to change(
+          Jobs::UpdateAkismetStatus.jobs,
+          :size,
+        ).by(1)
+      end
+    end
+
+    describe "#perform_confirm_spam" do
+      let(:action) { :confirm_spam }
+      let(:action_name) { "confirmed_spam" }
+      let(:flag_stat_status) { :agreed }
+
+      it_behaves_like "a staff action logger"
+      it_behaves_like "an Akismet feedback submission"
+
+      it "Confirms spam and reviewable status is changed to approved" do
+        result = reviewable.perform admin, action
+
+        expect(result.transition_to).to eq :approved
+      end
+    end
+
+    describe "#perform_not_spam" do
+      let(:action) { :not_spam }
+      let(:action_name) { "confirmed_ham" }
+      let(:flag_stat_status) { :disagreed }
+
+      it_behaves_like "a staff action logger"
+      it_behaves_like "an Akismet feedback submission"
+
+      it "Set post as clear and reviewable status is changed to rejected" do
+        result = reviewable.perform admin, action
+
+        expect(result.transition_to).to eq :rejected
+      end
+
+      it "Sends feedback to Akismet since post was not spam" do
+        expect { reviewable.perform admin, action }.to change(
+          Jobs::UpdateAkismetStatus.jobs,
+          :size,
+        ).by(1)
+      end
+
+      it "Recovers the post" do
+        reviewable.perform admin, action
+
+        recovered_post = post.reload
+
+        expect(recovered_post.deleted_at).to be_nil
+        expect(recovered_post.deleted_by).to be_nil
+      end
+
+      it "Does not try to recover the post if it was already recovered" do
+        post.update(deleted_at: nil)
+        event_triggered = false
+        blk = Proc.new { event_triggered = true }
+
+        begin
+          DiscourseEvent.on(:post_recovered, &blk)
+          reviewable.perform admin, action
+
+          expect(event_triggered).to eq false
+        ensure
+          DiscourseEvent.off(:post_recovered, &blk)
+        end
+      end
+
+      it "Sends a system message to the user" do
+        expect { reviewable.perform admin, action }.to change { Topic.private_messages.count }.by(1)
+
+        pm = Topic.private_messages.last
+        expect(pm.allowed_users).to contain_exactly(Discourse.system_user, post.user)
+      end
+
+      it "Does not send a system message to the user if topic is gone" do
+        first_post = Fabricate(:post_with_long_raw_content)
+        post = Fabricate(:post_with_long_raw_content, topic: first_post.topic)
+        PostDestroyer.new(Discourse.system_user, post).destroy
+        reviewable =
+          ReviewableAkismetPost.needs_review!(target: post, created_by: Discourse.system_user)
+        PostDestroyer.new(Discourse.system_user, first_post).destroy
+
+        expect { reviewable.perform admin, action }.not_to change { Topic.private_messages.count }
+      end
+    end
+
+    describe "#perform_ignore" do
+      let(:action) { :ignore }
+      let(:action_name) { "ignored" }
+      let(:flag_stat_status) { :ignored }
+
+      it_behaves_like "a staff action logger"
+
+      it "Set post as dismissed and reviewable status is changed to ignored" do
+        result = reviewable.perform admin, action
+
+        expect(result.transition_to).to eq :ignored
+      end
+    end
+
+    describe "#perform_delete_user" do
+      let(:action) { :delete_user }
+      let(:action_name) { "confirmed_spam_deleted" }
+      let(:flag_stat_status) { :agreed }
+
+      it_behaves_like "a staff action logger"
+      it_behaves_like "an Akismet feedback submission"
+
+      it "Confirms spam and reviewable status is changed to deleted" do
+        result = reviewable.perform admin, action
+
+        expect(result.transition_to).to eq :deleted
+      end
+
+      it "Deletes the user" do
+        reviewable.perform admin, action
+
+        expect(post.reload.user).to be_nil
+      end
+    end
+
+    describe "#perform_delete_user_block" do
+      let(:action) { :delete_user_block }
+      let(:action_name) { "confirmed_spam_deleted" }
+      let(:flag_stat_status) { :agreed }
+
+      it_behaves_like "a staff action logger"
+      it_behaves_like "an Akismet feedback submission"
+
+      it "Confirms spam and reviewable status is changed to deleted" do
+        result = reviewable.perform admin, action
+
+        expect(result.transition_to).to eq :deleted
+      end
+
+      it "Deletes the user" do
+        reviewable.perform admin, action
+
+        expect(post.reload.user).to be_nil
+      end
+    end
+  end
+
+  describe "Performing actions on reviewable API errors" do
+    let(:admin) { Fabricate(:admin) }
+    let(:post) { Fabricate(:post_with_long_raw_content) }
+    let(:reviewable) { ReviewableAkismetPost.needs_review!(target: post, created_by: admin).reload }
+
+    describe "#perform_confirm_spam" do
+      let(:action) { :confirm_spam }
+
+      it "Ensures the post has been deleted" do
+        reviewable.perform admin, action
+
+        updated_post = post.reload
+
+        expect(updated_post.deleted_at).not_to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -19,7 +19,6 @@ describe Plugin::Instance do
 
   it "marks post created by trust level 1 user for checking" do
     user_tl1_post_creator.create
-    byebug
     expect(DiscourseAkismet::PostsBouncer.to_check.length).to eq(1)
     expect(Jobs::CheckAkismetPost.jobs.length).to eq(0)
   end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -59,7 +59,7 @@ describe Plugin::Instance do
     expect(DiscourseAkismet::PostsBouncer.to_check.length).to eq(1)
     expect(Jobs::CheckAkismetPost.jobs.length).to eq(1)
 
-    expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq("pending")
+    expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::PENDING_STATE)
   end
 
   it "queues edited posts" do
@@ -79,7 +79,7 @@ describe Plugin::Instance do
 
     # Check original raw
     post = post_creator.create
-    expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq("pending")
+    expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::PENDING_STATE)
     expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
       "confirmed_ham",
     )
@@ -104,7 +104,7 @@ describe Plugin::Instance do
 
       # Check original raw
       post = post_creator.create
-      expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq("pending")
+      expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::PENDING_STATE)
       expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
         "confirmed_ham",
       )
@@ -133,7 +133,7 @@ describe Plugin::Instance do
         DiscourseAkismet::AntiSpamService.client,
         post.reload,
       )
-      expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq("skipped")
+      expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::SKIPPED_STATE)
 
       # Check the recovered post because it was not checked the first itme
       Jobs.run_immediately!

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -19,6 +19,7 @@ describe Plugin::Instance do
 
   it "marks post created by trust level 1 user for checking" do
     user_tl1_post_creator.create
+    byebug
     expect(DiscourseAkismet::PostsBouncer.to_check.length).to eq(1)
     expect(Jobs::CheckAkismetPost.jobs.length).to eq(0)
   end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -59,7 +59,9 @@ describe Plugin::Instance do
     expect(DiscourseAkismet::PostsBouncer.to_check.length).to eq(1)
     expect(Jobs::CheckAkismetPost.jobs.length).to eq(1)
 
-    expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::PENDING_STATE)
+    expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
+      DiscourseAkismet::Bouncer::PENDING_STATE,
+    )
   end
 
   it "queues edited posts" do
@@ -79,7 +81,9 @@ describe Plugin::Instance do
 
     # Check original raw
     post = post_creator.create
-    expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::PENDING_STATE)
+    expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
+      DiscourseAkismet::Bouncer::PENDING_STATE,
+    )
     expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
       "confirmed_ham",
     )
@@ -104,7 +108,9 @@ describe Plugin::Instance do
 
       # Check original raw
       post = post_creator.create
-      expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::PENDING_STATE)
+      expect(post.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
+        DiscourseAkismet::Bouncer::PENDING_STATE,
+      )
       expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
         "confirmed_ham",
       )
@@ -133,7 +139,9 @@ describe Plugin::Instance do
         DiscourseAkismet::AntiSpamService.client,
         post.reload,
       )
-      expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(DiscourseAkismet::Bouncer::SKIPPED_STATE)
+      expect(post.reload.custom_fields[DiscourseAkismet::Bouncer::AKISMET_STATE]).to eq(
+        DiscourseAkismet::Bouncer::SKIPPED_STATE,
+      )
 
       # Check the recovered post because it was not checked the first itme
       Jobs.run_immediately!


### PR DESCRIPTION
Context
 Akismet plugin allows customers to make use of Akismet a moderation tool in their forums.

**Problem**
Post Voting Comments are not currently  supported by the Akismet plugin.

**Solution**
Implement all required parts to make Akismet check and flag spam like it currently does for Posts.