### PR TITLE
DEV: Convert skip_akismet_trust_level to group setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,6 +4,7 @@ en:
     akismet_api_key: 'Akismet API key for spam checking'
     akismet_transmit_email: "Send the poster's email to Akismet when confirming spam"
     skip_akismet_trust_level: "Don't submit posts to Akismet if the user is this trust level or higher."
+    skip_akismet_groups: "Don't submit posts to Akismet if the user is in any of these groups."
     skip_akismet_posts: "Don't submit posts to Akismet if a user has posted this many times."
     akismet_notify_user: "Notify the user when Akismet has temporarily hidden a post."
     akismet_review_users: "Send TL0 user bios to Akismet for spam checking."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,13 @@ discourse_akismet:
   skip_akismet_trust_level:
     default: 1
     enum: 'TrustLevelSetting'
+    hidden: true
+  skip_akismet_groups:
+    default: "11" # TL 1 auto group
+    type: group_list
+    allow_any: false
+    refresh: true
+    validator: "AtLeastOneGroupValidator"
   akismet_notify_user:
     default: true
   skip_akismet_posts:

--- a/db/post_migrate/20240110040913_convert_skip_akismet_trust_level_to_group_setting.rb
+++ b/db/post_migrate/20240110040913_convert_skip_akismet_trust_level_to_group_setting.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ConvertSkipAkismetTrustLevelToGroupSetting < ActiveRecord::Migration[7.0]
+  def up
+    old_setting_trust_level =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'skip_akismet_trust_level' LIMIT 1",
+      ).first
+
+    if old_setting_trust_level.present?
+      allowed_groups = "1#{old_setting_trust_level}"
+
+      DB.exec(
+        "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
+        VALUES('skip_akismet_groups', :setting, '20', NOW(), NOW())",
+        setting: allowed_groups,
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Introduces skip_akismet_groups as part of our TL -> group
setting conversions.

c.f. https://meta.discourse.org/t/changes-coming-to-settings-for-giving-access-to-features-from-trust-levels-to-groups/283408
