### PR TITLE
FIX: Do not run job if the plugin is absent

### DIFF
--- a/jobs/scheduled/check_for_spam_post_voting_comments.rb
+++ b/jobs/scheduled/check_for_spam_post_voting_comments.rb
@@ -6,6 +6,7 @@ module Jobs
 
     def execute(args)
       return unless SiteSetting.akismet_enabled?
+      return unless defined?(SiteSetting.post_voting_enabled) && SiteSetting.post_voting_enabled?
       return if DiscourseAkismet::AntiSpamService.api_secret_blank?
 
       bouncer = DiscourseAkismet::PostVotingCommentsBouncer.new

--- a/spec/jobs/scheduled/check_for_spam_post_voting_comments_spec.rb
+++ b/spec/jobs/scheduled/check_for_spam_post_voting_comments_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Jobs::CheckForSpamPostsVotingComments do
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:comment) { Fabricate(:post_voting_comment, post: post) }
+
+  before do
+    SiteSetting.akismet_api_key = "test"
+    stub_request(:post, "https://test.rest.akismet.com/1.1/comment-check").to_return(
+      status: 200,
+      body: "true",
+    )
+    bouncer = DiscourseAkismet::PostVotingCommentsBouncer.new
+    bouncer.store_additional_information(comment, { ip_address: "", user_agent: "", referrer: "" })
+    bouncer.move_to_state(comment, DiscourseAkismet::Bouncer::PENDING_STATE)
+  end
+
+  it "does not trigger event if akismet is disabled" do
+    event =
+      DiscourseEvent.track(:akismet_found_spam) do
+        Jobs::CheckForSpamPostsVotingComments.new.execute(nil)
+      end
+    expect(event).not_to be_present
+  end
+
+  # not possible to test that the event is not triggerd due to absence of post_voting_enabled
+
+  it "does not trigger event if post_voting is disabled" do
+    SiteSetting.akismet_enabled = true
+    SiteSetting.post_voting_enabled = false
+
+    event =
+      DiscourseEvent.track(:akismet_found_spam) do
+        Jobs::CheckForSpamPostsVotingComments.new.execute(nil)
+      end
+
+    expect(event).not_to be_present
+  end
+
+  it "triggers an event when a pending comment exists" do
+    SiteSetting.akismet_enabled = true
+    SiteSetting.post_voting_enabled = true
+
+    event =
+      DiscourseEvent.track(:akismet_found_spam) do
+        Jobs::CheckForSpamPostsVotingComments.new.execute(nil)
+      end
+
+    expect(event).to be_present
+  end
+end

--- a/spec/jobs/scheduled/check_for_spam_post_voting_comments_spec.rb
+++ b/spec/jobs/scheduled/check_for_spam_post_voting_comments_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 RSpec.describe Jobs::CheckForSpamPostsVotingComments do
   fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE) }
   fab!(:post) { Fabricate(:post, topic: topic) }


### PR DESCRIPTION
Since akismet may be installed without the post-voting plugin, this job will run all the time and error out. This PR checks if the plugin is 'installed' and enabled prior to running.