### PR TITLE
DEV: Normalize reviewable actions

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -46,8 +46,11 @@ en:
       types:
         reviewable_akismet_post:
           title: "Akismet Flagged Post"
+          noun: "post"
         reviewable_akismet_user:
           title: "Akismet Flagged User"
+          noun: "user"
         reviewable_akismet_post_voting_comment:
           title: "Akismet Flagged Post Voting Comment"
+          noun: "post voting comment"
        

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -19,7 +19,7 @@ en:
       title: "Akismet"
       confirm_spam: "Delete Post"
       confirm_spam_description: "Agree with flag, delete the post and submit feedback to Akismet."
-      not_spam: "Not Spam"
+      not_spam: "No"
       confirm_delete: "Confirm Spam & Delete User"
       confirm_suspend: "Suspend User"
       confirm_suspend_description: "Agree with flag and suspend the user."

--- a/models/reviewable_akismet_post.rb
+++ b/models/reviewable_akismet_post.rb
@@ -10,29 +10,22 @@ class ReviewableAkismetPost < Reviewable
   def build_actions(actions, guardian, _args)
     return [] unless pending?
 
-    agree =
+    agree_bundle =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
 
-    build_action(actions, :confirm_spam, icon: "check", bundle: agree, has_description: true)
+    delete_user_actions(actions, agree_bundle) if guardian.can_delete_user?(target_created_by)
+
+    build_action(actions, :confirm_spam, icon: "check", bundle: agree_bundle, has_description: true)
 
     if guardian.can_suspend?(target_created_by)
       build_action(
         actions,
         :confirm_suspend,
         icon: "ban",
-        bundle: agree,
+        bundle: agree_bundle,
         client_action: "suspend",
         has_description: true,
       )
-    end
-
-    if guardian.can_delete_user?(target_created_by)
-      # TODO: Remove after the 2.8 release
-      if respond_to?(:delete_user_actions)
-        delete_user_actions(actions)
-      else
-        build_action(actions, :confirm_delete, icon: "trash-alt", bundle: agree, confirm: true)
-      end
     end
 
     build_action(actions, :not_spam, icon: "thumbs-down")

--- a/serializers/reviewable_akismet_post_serializer.rb
+++ b/serializers/reviewable_akismet_post_serializer.rb
@@ -4,4 +4,8 @@ require_dependency "reviewable_serializer"
 
 class ReviewableAkismetPostSerializer < ReviewableSerializer
   payload_attributes :post_cooked, :external_error
+
+  def created_from_flag?
+    true
+  end
 end


### PR DESCRIPTION
### What is this change?

Several pieces of feedback suggests that the review actions for posts flagged by Akismet are confusing. Since there is conceptually little difference between a post marked as spam by a human and a computer, this PR brings the options more in line with what we have for posts marked as spam in core.

### Before

![akismet-spam-before](https://github.com/discourse/discourse-akismet/assets/5259935/eab015f8-c4af-4ffd-8f21-be317de358f6)

### After

![akismet-spam-after](https://github.com/discourse/discourse-akismet/assets/5259935/3c0b1f4b-b2e7-4b9e-9a35-d390b4867ae4)