### PR TITLE
DEV: on migration conflict do nothing

### DIFF
--- a/db/post_migrate/20240110040913_convert_skip_akismet_trust_level_to_group_setting.rb
+++ b/db/post_migrate/20240110040913_convert_skip_akismet_trust_level_to_group_setting.rb
@@ -12,7 +12,8 @@ class ConvertSkipAkismetTrustLevelToGroupSetting < ActiveRecord::Migration[7.0]
 
       DB.exec(
         "INSERT INTO site_settings(name, value, data_type, created_at, updated_at)
-        VALUES('skip_akismet_groups', :setting, '20', NOW(), NOW())",
+        VALUES('skip_akismet_groups', :setting, '20', NOW(), NOW())
+        ON CONFLICT (name) DO NOTHING",
         setting: allowed_groups,
       )
     end


### PR DESCRIPTION
pre-seeded settings might conflict with the migrations - insert only if the key isn't present already