### PR TITLE
FIX: Missing translation for review_tl1_users_first_post_voting_comment

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,6 +9,7 @@ en:
     akismet_notify_user: "Notify the user when Akismet has temporarily hidden a post."
     akismet_review_users: "Send TL0 user bios to Akismet for spam checking."
     review_tl1_users_first_post: "Always review a TL1 user's first post."
+    review_tl1_users_first_post_voting_comment: "Always review a TL1 user's first post voting comment."
     anti_spam_service: "Anti-Spam service to use for automated spam detection"
     netease_secret_id: "NetEase API secret id"
     netease_secret_key: "NetEase API secret key"


### PR DESCRIPTION
Fixes the missing translation for the `review_tl1_users_first_post_voting_comment` site setting description.

<img width="654" alt="Screenshot 2024-02-27 at 10 32 36 PM" src="https://github.com/discourse/discourse-akismet/assets/22733864/f23a8d9b-4937-4f2e-967e-6895b14e924f">
