### PR TITLE
FIX: Display context question for Akismet flagged users

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -49,7 +49,7 @@ en:
           noun: "post"
         reviewable_akismet_user:
           title: "Akismet Flagged User"
-          noun: "user"
+          noun: "user profile"
         reviewable_akismet_post_voting_comment:
           title: "Akismet Flagged Post Voting Comment"
           noun: "post voting comment"

--- a/serializers/reviewable_akismet_user_serializer.rb
+++ b/serializers/reviewable_akismet_user_serializer.rb
@@ -7,6 +7,10 @@ class ReviewableAkismetUserSerializer < ReviewableSerializer
 
   attributes :user_deleted
 
+  def created_from_flag?
+    true
+  end
+
   def user_deleted
     object.target.nil?
   end


### PR DESCRIPTION
### What is this fix?

The context question is missing for reviewables where Akismet has marked a user profile as spam, causing the options to be ambiguous due to missing context.

This PR fixes that.

**Before:**

<img width="286" alt="Screenshot 2024-03-25 at 4 28 47 PM" src="https://github.com/discourse/discourse-akismet/assets/5259935/0fea2e41-7178-4d8b-ae1d-e77944fd6f3b">

**After:**

<img width="270" alt="Screenshot 2024-03-25 at 4 28 24 PM" src="https://github.com/discourse/discourse-akismet/assets/5259935/5cd14e0a-4c9e-4949-a738-b1f5a1d8b2a8">
