### PR TITLE
FIX: send email to user and not admin about deletion

### DIFF
--- a/models/reviewable_akismet_post.rb
+++ b/models/reviewable_akismet_post.rb
@@ -81,7 +81,7 @@ class ReviewableAkismetPost < Reviewable
       PostDestroyer.new(performed_by, post).destroy unless post.deleted_at?
 
       opts = user_deletion_opts(performed_by, args)
-      email = performed_by.email
+      email = target_created_by.email
       UserDestroyer.new(performed_by).destroy(target_created_by, opts)
 
       message = UserNotifications.account_deleted(email, self)

--- a/spec/models/reviewable_akismet_post_spec.rb
+++ b/spec/models/reviewable_akismet_post_spec.rb
@@ -222,6 +222,7 @@ describe "ReviewableAkismetPost" do
         expect { reviewable.perform(admin, action) }.to change {
           ActionMailer::Base.deliveries.count
         }
+        expect(ActionMailer::Base.deliveries.last.to).to eq([post.user.email])
         expect(ActionMailer::Base.deliveries.last.subject).to include(
           I18n.t("user_notifications.account_deleted.subject_template", email_prefix: "Discourse"),
         )
@@ -252,6 +253,7 @@ describe "ReviewableAkismetPost" do
         expect { reviewable.perform(admin, action) }.to change {
           ActionMailer::Base.deliveries.count
         }
+        expect(ActionMailer::Base.deliveries.last.to).to eq([post.user.email])
         expect(ActionMailer::Base.deliveries.last.subject).to include(
           I18n.t("user_notifications.account_deleted.subject_template", email_prefix: "Discourse"),
         )


### PR DESCRIPTION
Bug introduced in this PR - https://github.com/discourse/discourse-akismet/pull/167

When user is deleted, email should be sent to target user and not admin performing.