### PR TITLE
FEATURE: Update the ReviewableAkismetPost UI

### DIFF
--- a/assets/javascripts/discourse/components/reviewable-refresh/akismet-post.gjs
+++ b/assets/javascripts/discourse/components/reviewable-refresh/akismet-post.gjs
@@ -1,0 +1,17 @@
+import ReviewablePost from "discourse/components/reviewable-refresh/post";
+import { i18n } from "discourse-i18n";
+import ReviewableAkismetApiError from "../reviewable-akismet-api-error";
+
+<template>
+  <ReviewablePost
+    @reviewable={{@reviewable}}
+    @userLabel={{i18n "review.flagged_user"}}
+    @pluginOutletName="after-reviewable-akismet-post-body"
+  >
+    {{#if @reviewable.payload.external_error}}
+      <ReviewableAkismetApiError
+        @external_error={{@reviewable.payload.external_error}}
+      />
+    {{/if}}
+  </ReviewablePost>
+</template>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -27,7 +27,7 @@ en:
           complete: "Post deleted and marked as spam"
         not_spam:
           title: "Not Spam"
-          description: "Mark as ham and recover the post if deleted"
+          description: "Mark as not spam and recover the post if deleted"
           complete: "Marked as not spam"
         confirm_suspend:
           title: "Suspend User"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -18,6 +18,28 @@ en:
   akismet:
     delete_reason: "determined by %{performed_by} to be a spammer"
 
+  discourse_akismet:
+    reviewables:
+      actions:
+        confirm_spam:
+          title: "Confirm Spam"
+          description: "Delete the post and submit spam feedback to Akismet"
+          complete: "Post deleted and marked as spam"
+        not_spam:
+          title: "Not Spam"
+          description: "Mark as ham and recover the post if deleted"
+          complete: "Marked as not spam"
+        confirm_suspend:
+          title: "Suspend User"
+          description: "Suspend the user and delete the spam post"
+          complete: "User suspended and post deleted"
+        ignore:
+          title: "Ignore"
+          description: "Ignore this Akismet flag"
+          complete: "Akismet flag ignored"
+        akismet_actions:
+          bundle_title: "Akismet Actions"
+
   reviewables:
     reasons:
       akismet_spam_post: "Akismet flagged this post as potential spam. See more at %{link}."

--- a/serializers/reviewable_akismet_post_serializer.rb
+++ b/serializers/reviewable_akismet_post_serializer.rb
@@ -3,6 +3,7 @@
 require_dependency "reviewable_serializer"
 
 class ReviewableAkismetPostSerializer < ReviewableSerializer
+  target_attributes :cooked
   payload_attributes :post_cooked, :external_error
 
   def created_from_flag?

--- a/spec/system/viewing_reviewable_akismet_post_spec.rb
+++ b/spec/system/viewing_reviewable_akismet_post_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+describe "Viewing reviewable akismet post", type: :system do
+  fab!(:admin)
+  fab!(:group)
+  fab!(:post)
+  fab!(:reviewable) { Fabricate(:reviewable_akismet_post, target: post, topic: post.topic) }
+
+  let(:refreshed_review_page) { PageObjects::Pages::RefreshedReview.new }
+
+  before do
+    SiteSetting.reviewable_old_moderator_actions = false
+    SiteSetting.reviewable_ui_refresh = group.name
+    group.add(admin)
+    sign_in(admin)
+  end
+
+  it "allows to confirm spam" do
+    refreshed_review_page.visit_reviewable(reviewable)
+
+    expect(page).to have_text(post.raw)
+
+    refreshed_review_page.select_bundled_action(reviewable, "post-confirm_spam")
+    expect(refreshed_review_page).to have_reviewable_with_approved_status(reviewable)
+  end
+
+  it "allows to mark as not spam" do
+    post.trash!(admin)
+
+    refreshed_review_page.visit_reviewable(reviewable)
+
+    refreshed_review_page.select_bundled_action(reviewable, "post-not_spam")
+    expect(refreshed_review_page).to have_reviewable_with_rejected_status(reviewable)
+  end
+
+  it "allows to ignore" do
+    refreshed_review_page.visit_reviewable(reviewable)
+
+    refreshed_review_page.select_bundled_action(reviewable, "post-ignore")
+
+    expect(refreshed_review_page).to have_reviewable_with_ignored_status(reviewable)
+  end
+
+  it "shows API errors if present" do
+    reviewable.update(
+      payload: {
+        post_cooked: post.cooked,
+        external_error: {
+          error: "Rate limit exceeded",
+          code: 429,
+          msg: "Too many requests",
+        },
+      },
+    )
+
+    refreshed_review_page.visit_reviewable(reviewable)
+
+    expect(page).to have_text("Akismet API Error:")
+    expect(page).to have_text("Rate limit exceeded")
+  end
+end

--- a/spec/system/viewing_reviewable_akismet_post_spec.rb
+++ b/spec/system/viewing_reviewable_akismet_post_spec.rb
@@ -33,7 +33,7 @@ describe "Viewing reviewable akismet post", type: :system do
     expect(refreshed_review_page).to have_reviewable_with_rejected_status(reviewable)
   end
 
-  it "allows to ignore" do
+  it "allows the reviewer to mark the reviewable as ignored" do
     refreshed_review_page.visit_reviewable(reviewable)
 
     refreshed_review_page.select_bundled_action(reviewable, "post-ignore")

--- a/spec/system/viewing_reviewable_akismet_post_spec.rb
+++ b/spec/system/viewing_reviewable_akismet_post_spec.rb
@@ -24,7 +24,7 @@ describe "Viewing reviewable akismet post", type: :system do
     expect(refreshed_review_page).to have_reviewable_with_approved_status(reviewable)
   end
 
-  it "allows to mark as not spam" do
+  it "allows the reviewer to mark the reviewable as not spam" do
     post.trash!(admin)
 
     refreshed_review_page.visit_reviewable(reviewable)

--- a/spec/system/viewing_reviewable_akismet_post_spec.rb
+++ b/spec/system/viewing_reviewable_akismet_post_spec.rb
@@ -15,7 +15,7 @@ describe "Viewing reviewable akismet post", type: :system do
     sign_in(admin)
   end
 
-  it "allows to confirm spam" do
+  it "allows user to confirm reviewable as spam" do
     refreshed_review_page.visit_reviewable(reviewable)
 
     expect(page).to have_text(post.raw)


### PR DESCRIPTION
Refactored ReviewableAkismetComment model to support both legacy and new UI patterns
- Renamed build_actions to build_legacy_combined_actions for backward compatibility
- Added build_new_separated_actions for the new UI action pattern Created new akisment-post.gjs Glimmer component to display reviewable 
- Added system specs covering basic actions

<img width="1391" height="1108" alt="Screenshot 2025-11-05 at 1 11 45 pm" src="https://github.com/user-attachments/assets/8f89d194-45ca-4ac9-b2ac-8ae1ef884524" />

Missing spec helper added to Core in this PR https://github.com/discourse/discourse/pull/35824
