### PR TITLE
DEV: serialize link_admin for refreshed review queue

### DIFF
--- a/serializers/reviewable_akismet_user_serializer.rb
+++ b/serializers/reviewable_akismet_user_serializer.rb
@@ -5,7 +5,7 @@ require_dependency "reviewable_serializer"
 class ReviewableAkismetUserSerializer < ReviewableSerializer
   payload_attributes :username, :name, :email, :bio, :external_error
 
-  attributes :user_deleted
+  attributes :user_deleted, :link_admin
 
   def created_from_flag?
     true
@@ -13,5 +13,9 @@ class ReviewableAkismetUserSerializer < ReviewableSerializer
 
   def user_deleted
     object.target.nil?
+  end
+
+  def link_admin
+    scope.is_staff? && object.target.present?
   end
 end

--- a/spec/fabricators/reviewable_akismet_post_fabricator.rb
+++ b/spec/fabricators/reviewable_akismet_post_fabricator.rb
@@ -36,4 +36,13 @@ Fabricator(:reviewable_akismet_user) do
       ]
     end
   end
+  payload do |attrs|
+    user = attrs[:target]
+    {
+      username: user.username,
+      name: user.name,
+      email: user.email,
+      bio: user.user_profile.bio_raw,
+    }
+  end
 end

--- a/spec/system/viewing_reviewable_akismet_user_spec.rb
+++ b/spec/system/viewing_reviewable_akismet_user_spec.rb
@@ -39,4 +39,13 @@ describe "Viewing reviewable akismet user", type: :system do
 
     expect(refreshed_review_page).to have_reviewable_with_rejected_status(reviewable)
   end
+
+  it "displays username as a link to admin page for staff" do
+    refreshed_review_page.visit_reviewable(reviewable)
+
+    expect(page).to have_link(
+      reviewable.target.username,
+      href: "/admin/users/#{reviewable.target.id}/#{reviewable.target.username}",
+    )
+  end
 end


### PR DESCRIPTION
In the old layout we link to the user, but in the refreshed review queue this link was missing because it relies on a new field. This adds it! 

Before:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/aaaa0e71-d9a6-465e-b6a5-d914a38827e9" />


After: 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/8b70edfd-b97f-44e6-9c06-2cc90f083db2" />


