### PR TITLE
 DEV: specs use old reviewable moderator actions UI

### DIFF
--- a/spec/system/viewing_reviewable_akismet_post_spec.rb
+++ b/spec/system/viewing_reviewable_akismet_post_spec.rb
@@ -9,7 +9,7 @@ describe "Viewing reviewable akismet post", type: :system do
   let(:refreshed_review_page) { PageObjects::Pages::RefreshedReview.new }
 
   before do
-    SiteSetting.reviewable_old_moderator_actions = false
+    SiteSetting.reviewable_old_moderator_actions = true
     group.add(admin)
     sign_in(admin)
   end
@@ -19,7 +19,7 @@ describe "Viewing reviewable akismet post", type: :system do
 
     expect(page).to have_text(post.raw)
 
-    refreshed_review_page.select_bundled_action(reviewable, "post-confirm_spam")
+    page.find(".post-confirm-spam").click
     expect(refreshed_review_page).to have_reviewable_with_approved_status(reviewable)
   end
 

--- a/spec/system/viewing_reviewable_akismet_user_spec.rb
+++ b/spec/system/viewing_reviewable_akismet_user_spec.rb
@@ -8,7 +8,7 @@ describe "Viewing reviewable akismet user", type: :system do
   let(:refreshed_review_page) { PageObjects::Pages::RefreshedReview.new }
 
   before do
-    SiteSetting.reviewable_old_moderator_actions = false
+    SiteSetting.reviewable_old_moderator_actions = true
     group.add(admin)
     sign_in(admin)
   end
@@ -34,7 +34,7 @@ describe "Viewing reviewable akismet user", type: :system do
   it "allows the reviewer to mark the reviewable as rejected" do
     refreshed_review_page.visit_reviewable(reviewable)
 
-    refreshed_review_page.select_bundled_action(reviewable, "user-ignore")
+    page.find(".user-not-spam").click
 
     expect(refreshed_review_page).to have_reviewable_with_rejected_status(reviewable)
   end


### PR DESCRIPTION
 Old reviewable moderator actions will be default. Therefore we need
 tests with this option enabled.

 Related PR https://github.com/discourse/discourse/pull/36752