### PR TITLE
FIX: Ensure valid permissions to view email in Akismet reviewable

### DIFF
--- a/serializers/reviewable_akismet_user_serializer.rb
+++ b/serializers/reviewable_akismet_user_serializer.rb
@@ -11,6 +11,16 @@ class ReviewableAkismetUserSerializer < ReviewableSerializer
     true
   end
 
+  def attributes(*args)
+    data = super
+    data[:payload]&.delete("email") if !include_email?
+    data
+  end
+
+  def include_email?
+    scope.can_check_emails?(scope.user)
+  end
+
   def user_deleted
     object.target.nil?
   end

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe ReviewablesController do
+  fab!(:moderator)
+  fab!(:reviewable, :reviewable_akismet_user)
+
+  before do
+    SiteSetting.akismet_enabled = true
+    SiteSetting.moderators_view_emails = false
+
+    sign_in(moderator)
+  end
+
+  describe "#show" do
+    it "filters the email payload by reviewer permission" do
+      get "/review/#{reviewable.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["reviewable"]["payload"]).not_to have_key("email")
+
+      SiteSetting.moderators_view_emails = true
+
+      get "/review/#{reviewable.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["reviewable"]["payload"]["email"]).to eq(reviewable.target.email)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Moderators did not respect the `moderators_view_emails` site setting allowing them to view user email addresses by viewing Akismet user reviews in the review queue.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1223

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>